### PR TITLE
Don't include hosts list in slave's app.config

### DIFF
--- a/ansible/roles/amoc/templates/app.config.j2
+++ b/ansible/roles/amoc/templates/app.config.j2
@@ -1,5 +1,5 @@
 [
- {amoc, [{hosts, [{% for h in amoc_slaves %} "{{h}}" {% if not loop.last %},{% endif %} {% endfor %}] },
+ {amoc, [{hosts, [{% if 'amoc-master' in group_names %}{% for h in amoc_slaves %} "{{h}}" {% if not loop.last %},{% endif %}{% endfor %}{% endif %}] },
          {path, "{{ slave_install_dir }}" },
          {interarrival, 75},
          {graphite_endpoint, "{{ graphite_ip }}:{{ graphite_http_port }}"}]},


### PR DESCRIPTION
Including hostnames of all the slave nodes in the slaves' app.config file breaks detection of the master going down.