### PR TITLE
enable kernel polling

### DIFF
--- a/ansible/roles/amoc/templates/vm.args.j2
+++ b/ansible/roles/amoc/templates/vm.args.j2
@@ -9,7 +9,7 @@
 ##-heart
 
 ## Enable kernel poll and a few async threads
-##+K true
++K true
 ##+A 5
 
 ## Increase number of concurrent ports/sockets

--- a/priv/vm.args
+++ b/priv/vm.args
@@ -9,7 +9,7 @@
 ##-heart
 
 ## Enable kernel poll and a few async threads
-##+K true
++K true
 ##+A 5
 
 ## Increase number of concurrent ports/sockets


### PR DESCRIPTION
My recent tests shows that:
* with kernel polling we don't consume big amount of `system time`, without kernel polling it was up to 50% system time ... 
* latency decreased, test that measures time to deliver is significantly lower(up to 10x). I was load testing the mongoose_simple_with_metrics scenario, so look there for the time to deliver metric details. 