### PR TITLE
[WIP] Configuration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,51 @@ To prevent that start the amoc node in the background using `bin/amoc start`.
 Now you can run commands by attaching to the amoc's node with `bin/amoc attach`,
 typing a command and then pressing Ctrl+D to exit the shell.
 After that the scenario will keep running.
+
+## Configuration
+
+amoc is configured through OTP application environmental variables that
+are loaded from the configuration file
+
+Internally, amoc is using the following settings:
+
+- ``interarrival`` - a delay in ms, for each node, between creating process
+  for two consecutive users. Defaults to 50 ms.
+- ``repeat_interval`` - a delay in ms, for each user process that it waits
+  before starting the same scenario again. Defaults to 1 minute.
+- ``repeat_num`` - number of scenario repetitions for each process.
+  Defaults to ``infinity``.
+
+You can also define your own entries that you might later use in your
+scenarios.
+
+The ``amoc_config`` module, that is essentially a wrapper around functions
+manipulation the application's environment in the ``application`` module.
+
+``amoc_config`` provides the following functions:
+
+- ``get(Name)`` and ``get(Name, Default)`` - return the value for the
+  given config entry, all values defined in the config file are available
+- ``set(Name, Value)`` - sets the new value for the given entry. You might
+  use it inside your scenario to make scenario more dynamic.
+
+### Locally (without ansible)
+
+If you are not using ansible, just modify the ``priv/app.config`` file.
+It will later be added to your local release.
+
+### Distributed (with ansible)
+
+During the ansible deployment the following file is used as a template:
+``ansible/roles/amoc/templates/app.config.j2``.
+
+As long as you need to set only the amoc application variables (including
+your scenario-specific settings), you can do
+it in the ``ansible/group_vars/amoc`` file.
+
+A separate file is required for this
+since dictionaries are not supported in the inventory file.
+
+### Docker
+
+TODO

--- a/ansible/group_vars/amoc
+++ b/ansible/group_vars/amoc
@@ -1,0 +1,2 @@
+amoc:
+    interarrival: 75

--- a/ansible/roles/amoc/templates/app.config.j2
+++ b/ansible/roles/amoc/templates/app.config.j2
@@ -1,8 +1,9 @@
 [
  {amoc, [{hosts, [{% if 'amoc-master' in group_names %}{% for h in amoc_slaves %} "{{h}}" {% if not loop.last %},{% endif %}{% endfor %}{% endif %}] },
          {path, "{{ slave_install_dir }}" },
-         {interarrival, 75},
-         {graphite_endpoint, "{{ graphite_ip }}:{{ graphite_http_port }}"}]},
+         {graphite_endpoint, "{{ graphite_ip }}:{{ graphite_http_port }}"}
+         {% for key, value in amoc.iteritems() %},{ {{ key }}, {{ value }} }{% endfor %}
+        ]},
  {exometer, [
     {predefined, [
         {[erlang, system_info],

--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,6 @@
         {exometer, ".*", {git, "git://github.com/Feuerlabs/exometer.git", "7a7bd8d2b52de4d90f65aa3f6044b0e988319b9e"}},
         {lhttpc, ".*", {git, "git://github.com/esl/lhttpc.git", {branch, "otp-17-compat"}}},
         {mochijson2, ".*", {git, "git://github.com/bjnortier/mochijson2.git", {branch, "master"}}},
+        {proper, ".*", {git, "git://github.com/manopapad/proper.git", {branch, "master"}}},
         {recon, ".*", {git, "https://github.com/ferd/recon.git", "2.2.1"}}
        ]}.

--- a/src/amoc.erl
+++ b/src/amoc.erl
@@ -3,9 +3,6 @@
 %% Licensed under the Apache License, Version 2.0 (see LICENSE file)
 %%==============================================================================
 -module(amoc).
--define(INTERARRIVAL_DEFAULT, 30).
--define(INTERARRIVAL,
-    application:get_env(amoc, interarrival, ?INTERARRIVAL_DEFAULT)).
 
 -export([do/1]).
 

--- a/src/amoc_annotations.erl
+++ b/src/amoc_annotations.erl
@@ -63,10 +63,10 @@ code_change(_OldVsn, State, _Extra) ->
 %% ------------------------------------------------------------------
 -spec annotate(tag(), list(), list(any())) -> {error, no_graphite} | ok.
 annotate(Tags, Format, Args) ->
-    case application:get_env(amoc, graphite_endpoint) of
+    case amoc_config:get(graphite_endpoint) of
         undefined ->
             {error, no_graphite};
-        {ok, Host} ->
+        Host ->
             What = iolist_to_binary(io_lib:format(Format, Args)),
             Struct = {struct, [{what, What}, {tags, Tags}]},
             Json = mochijson2:encode(Struct),

--- a/src/amoc_app.erl
+++ b/src/amoc_app.erl
@@ -15,6 +15,7 @@
 
 -spec start(application:start_type(), term()) -> {ok, pid()}.
 start(_StartType, _StartArgs) ->
+    ok = amoc_config:start(),
     Ret = amoc_sup:start_link(),
     amoc_dist:start_nodes(),
     ok = amoc_event:add_handler(amoc_annotations, []),

--- a/src/amoc_config.erl
+++ b/src/amoc_config.erl
@@ -1,0 +1,67 @@
+%%==============================================================================
+%% Copyright 2016 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+-module(amoc_config).
+
+-export([start/0,
+         set/2,
+         get/1,
+         get/2,
+         fetch/1]).
+
+%% For tests
+-export([set_env_variables/2]).
+
+%% ------------------------------------------------------------------
+%% API
+%% ------------------------------------------------------------------
+-spec start() -> ok.
+start() ->
+    ok = set_env_variables(os:getenv()).
+
+-spec set(atom(), any()) -> ok.
+set(Name, Value) ->
+    ok = application:set_env(amoc, Name, Value).
+
+-spec get(atom()) -> any().
+get(Name) ->
+    get(Name, undefined).
+
+-spec get(atom(), any()) -> any().
+get(Name, Default) ->
+    application:get_env(amoc, Name, Default).
+
+-spec fetch(atom()) -> any().
+fetch(Name) ->
+    case application:get_env(amoc, Name) of
+        {ok, Value} -> Value;
+        undefined -> throw({key_not_found, Name})
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+-spec set_env_variables([string()]) -> ok.
+set_env_variables(EnvVars) ->
+    set_env_variables(EnvVars, fun(_) -> true end).
+
+-spec set_env_variables([string()], fun((string()) -> boolean())) -> ok.
+set_env_variables(EnvVars, Filter) ->
+    Vars = parse_variables(EnvVars),
+    [ ok = set(Name, Value) || {Name, Value} <- Vars, Filter(Name) ],
+    ok.
+
+-spec parse_variables([string()]) -> [{atom(), any()}].
+parse_variables(EnvVars) ->
+    Vars = [ re:split(Var, "=", [{return, list}, {parts, 2}])
+             || Var <- EnvVars ],
+    %% list_to_atom should be safe here, as we are in control of env variables
+    [ {list_to_atom(Name), parse_value(Value)} ||
+      ["AMOC_" ++ Name, Value] <- Vars ].
+
+-spec parse_value(string()) -> any().
+parse_value(String) ->
+    {ok, Tokens, _} = erl_scan:string(String ++ "."),
+    {ok, Term} = erl_parse:parse_term(Tokens),
+    Term.

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -4,11 +4,11 @@
 %%==============================================================================
 -module(amoc_controller).
 -behaviour(gen_server).
+
 -define(SERVER, ?MODULE).
 -define(INTERARRIVAL_DEFAULT, 50).
--define(INTERARRIVAL,
-        application:get_env(amoc, interarrival, ?INTERARRIVAL_DEFAULT)).
 -define(TABLE, amoc_users).
+
 -record(state, {scenario :: amoc:scenario(),
                 scenario_state :: any(),
                 nodes ::  non_neg_integer(),
@@ -225,7 +225,7 @@ start_users(Scenario, UserIds, State) ->
     supervisor:startchild_ret().
 start_user(Scenario, Id, State) ->
     R = supervisor:start_child(amoc_users_sup, [Scenario, Id, State]),
-    timer:sleep(?INTERARRIVAL),
+    timer:sleep(interarrival()),
     R.
 
 -spec stop_users([amoc_scenario:user_id()], boolean()) -> [true | stop].
@@ -268,3 +268,7 @@ node_userids(Start, End, Nodes, NodeId) when is_integer(Nodes), Nodes > 0,
                 false
         end,
     lists:filter(F, lists:seq(Start, End)).
+
+-spec interarrival() -> integer().
+interarrival() ->
+    amoc_config:get(interarrival, ?INTERARRIVAL_DEFAULT).

--- a/src/amoc_dist.erl
+++ b/src/amoc_dist.erl
@@ -16,8 +16,8 @@
 %% ------------------------------------------------------------------
 -spec start_nodes() -> [ok].
 start_nodes() ->
-    Hosts = application:get_env(amoc, hosts, []),
-    Path = application:get_env(amoc, path, "/usr"),
+    Hosts = amoc_config:get(hosts, []),
+    Path = amoc_config:get(path, "/usr"),
     start_nodes(Hosts, Path).
 
 -spec do(amoc:scenario(), amoc_scenario:user_id(), amoc_scenario:user_id()) ->

--- a/src/amoc_user.erl
+++ b/src/amoc_user.erl
@@ -77,7 +77,7 @@ repeat(F, 1) ->
     F().
 
 repeat_interval() ->
-    application:get_env(amoc, repeat_interval, ?REPEAT_INTERVAL).
+    amoc_config:get(repeat_interval, ?REPEAT_INTERVAL).
 
 repeat_num() ->
-    application:get_env(amoc, repeat_num, ?REPEAT_NUM).
+    amoc_config:get(repeat_num, ?REPEAT_NUM).

--- a/test/config_SUITE.erl
+++ b/test/config_SUITE.erl
@@ -1,0 +1,125 @@
+-module(config_SUITE).
+
+-behaviour(proper_statem).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+suite() -> [].
+
+groups() -> [].
+
+all() ->
+    [config_osenv_test,
+     config_prop_test].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_group, Config) ->
+    Config.
+
+end_per_group(_group, Config) ->
+    Config.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+config_osenv_test(_Config) ->
+    given_osenv_set([{"AMOC_interarrival", "100"},
+                     {"AMOC_something", "[{a,b,c}, 9, 8, {7}]"}]),
+    given_amoc_started(),
+    ?assertEqual(100, amoc_config:get(interarrival)),
+    ?assertEqual(60000, amoc_config:get(repeat_interval)),
+    ?assertEqual(something, amoc_config:get(anything, something)),
+    ?assertEqual([{a,b,c},9,8,{7}], amoc_config:get(something)).
+
+given_amoc_started() ->
+    {ok, _} = application:ensure_all_started(amoc).
+
+given_osenv_set(Envs) ->
+    [ true = os:putenv(Name, Value) || {Name, Value} <- Envs ].
+
+config_prop_test(_Config) ->
+     ?assertEqual(true, proper:quickcheck(config_prop(), [long_result, 100])).
+
+config_prop() ->
+    ?FORALL(Cmds, proper_statem:commands(?MODULE),
+            begin
+                {_History, State, Result} = proper_statem:run_commands(?MODULE, Cmds),
+                unset_all(State),
+                Result =:= ok
+            end).
+
+key() ->
+    oneof([a, b, c, d, e, f, g]).
+
+%% Abstract state machine
+initial_state() ->
+    #{vars => [], envs => []}.
+
+command(_S) ->
+    oneof([
+           {call, amoc_config, set, [key(), any()]},
+           {call, amoc_config, get, [key()]},
+           {call, amoc_config, get, [key(), any()]},
+           {call, ?MODULE, set_env_variable, [key(), any()]},
+           {call, ?MODULE, safe_fetch, [key()]}
+           ]).
+
+%%
+precondition(_S, _) ->
+    true.
+
+%%
+next_state(S=#{vars := Vars}, _Res, {call, amoc_config, set, [Key, Value]}) ->
+    S#{vars := lists:keystore(Key, 1, Vars, {Key, Value})};
+
+next_state(S=#{vars := Vars, envs := Envs}, _Res,
+           {call, ?MODULE, set_env_variable, [Key, Value]}) ->
+    S#{vars := lists:keystore(Key, 1, Vars, {Key, Value}),
+       envs := [Key | Envs]};
+
+next_state(S, _Res, {call, _, _, _}) ->
+    S.
+
+%%
+postcondition(#{vars := Vars}, {call, amoc_config, get, [Key]}, Res) ->
+    proplists:get_value(Key, Vars) =:= Res;
+
+postcondition(#{vars := Vars}, {call, amoc_config, get, [Key, Default]}, Res) ->
+    proplists:get_value(Key, Vars, Default) =:= Res;
+
+postcondition(#{vars := Vars}, {call, amoc_config, safe_fetch, [Key]},
+              {key_not_found, Key}) ->
+    false =:= lists:keyfind(Key, 1, Vars);
+
+postcondition(#{vars := Vars}, {call, amoc_config, safe_fetch, [Key]}, Res) ->
+    {Key, Value} = lists:keyfind(Key, 1, Vars),
+    Value =:= Res;
+
+postcondition(_S, {call, _, _, _}, _Res) ->
+    true.
+
+%% statem helpers
+set_env_variable(Name, Value) ->
+    EnvName = "AMOC_" ++ atom_to_list(Name),
+    true = os:putenv(EnvName, lists:flatten(io_lib:format("~p", [Value]))),
+    %% Reset only this env variable in the application
+    ok = amoc_config:set_env_variables(os:getenv(), fun(N) -> N =:= Name end).
+
+safe_fetch(Name) ->
+    catch amoc_config:fetch(Name).
+
+unset_all(#{envs := Envs}) ->
+    [ true = os:unsetenv("AMOC_" ++ atom_to_list(Env)) || Env <- Envs ],
+    [ ok = application:unset_env(amoc, Name)
+      || {Name, _} <- application:get_all_env(amoc) ].


### PR DESCRIPTION
The ``amoc_config`` helper (wrapper around ``application:get/set_env``) is added to facilitate usage of dynamic configuration inside the scenarios.
Also, mainly for usage with Docker containers, all environmental variables starting with ``AMOC_name`` will be stored as application variables (the value of these variables will be parsed as Erlang terms).

To do before this PR might be considered in a ready-to-merge state:
- [ ] update README
- [ ] prepare a scenario using dynamic config
- [ ] fix the current mess with the calls to ``application:get_env`` inside macros.