### PR TITLE
Better REST API status description

### DIFF
--- a/src/amoc_api_status_handler.erl
+++ b/src/amoc_api_status_handler.erl
@@ -49,7 +49,7 @@ content_types_provided(Req, State) ->
     {binary(), cowboy_req:req(), state()}.
 to_json(Req0, State) ->
     Status = get_status(),
-    StatusJson = jsx:encode([{result, Status}]),
+    StatusJson = jsx:encode([{node_status, Status}]),
     {StatusJson, Req0, State}.
     
 -spec get_status() -> boolean().
@@ -57,6 +57,6 @@ get_status() ->
     Results = application:which_applications(),
     Res = lists:keyfind(amoc, 1, Results),
     case Res of
-        {amoc, _Desc, _Vsn} -> true;
-        false -> false
+        {amoc, _Desc, _Vsn} -> up;
+        false -> down
     end.

--- a/test/amoc_api_status_handler_SUITE.erl
+++ b/test/amoc_api_status_handler_SUITE.erl
@@ -4,16 +4,16 @@
 -include_lib("eunit/include/eunit.hrl").
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 
--export([returns_true_when_amoc_up_offline/1,
-         returns_true_when_amoc_up_online/1,
-         returns_false_when_api_up_and_amoc_down_offline/1,
-         returns_false_when_api_up_and_amoc_down_online/1]).
+-export([returns_up_when_amoc_up_offline/1,
+         returns_up_when_amoc_up_online/1,
+         returns_down_when_api_up_and_amoc_down_offline/1,
+         returns_down_when_api_up_and_amoc_down_online/1]).
 
 all() ->
-    [returns_true_when_amoc_up_offline,
-     returns_true_when_amoc_up_online,
-     returns_false_when_api_up_and_amoc_down_offline,
-     returns_false_when_api_up_and_amoc_down_online].
+    [returns_up_when_amoc_up_offline,
+     returns_up_when_amoc_up_online,
+     returns_down_when_api_up_and_amoc_down_offline,
+     returns_down_when_api_up_and_amoc_down_online].
 
 init_per_testcase(_, Config) ->
     application:ensure_all_started(inets),
@@ -24,40 +24,40 @@ end_per_testcase(_, _Config) ->
     application:stop(amoc),
     amoc_api:stop().
 
-returns_true_when_amoc_up_offline(_Config) ->
+returns_up_when_amoc_up_offline(_Config) ->
     %% given
     given_applications_started(),
     %% when
     Status = amoc_api_status_handler:get_status(),
     %% then
-    ?assert(Status).
+    ?assertEqual(up, Status).
 
-returns_true_when_amoc_up_online(_Config) ->
+returns_up_when_amoc_up_online(_Config) ->
     %% given
     given_applications_started(),
     %% when
     {CodeHttp, Body} = send_request(),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"result">>, true}], Body).
+    ?assertMatch([{<<"node_status">>, <<"up">>}], Body).
 
 
-returns_false_when_api_up_and_amoc_down_offline(_Config) ->
+returns_down_when_api_up_and_amoc_down_offline(_Config) ->
     %% given
     given_http_api_started(),
     %% when
     Status = amoc_api_status_handler:get_status(),
     %% then
-    ?assertNot(Status).
+    ?assertEqual(down, Status).
  
-returns_false_when_api_up_and_amoc_down_online(_Config) ->
+returns_down_when_api_up_and_amoc_down_online(_Config) ->
     %% given
     given_http_api_started(),
     %% when
     {CodeHttp, Body} = send_request(),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"result">>, false}], Body).
+    ?assertMatch([{<<"node_status">>, <<"down">>}], Body).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% HELPERS


### PR DESCRIPTION
When we do `GET /status` on response we have `{ node_status: up | down }` instead of `{ status: true | false }`.