### PR TITLE
Add node listing on GET /nodes

### DIFF
--- a/src/amoc_api_node_handler.erl
+++ b/src/amoc_api_node_handler.erl
@@ -16,12 +16,12 @@
 -spec trails() -> trails:trails().
 trails() ->
     Metadata =
-        #{get =>
-              #{tags => ["node"],
-                description => "Pings AMOC nodes from master node",
-                produces => ["application/json"]
-               }
-         },
+    #{get =>
+          #{tags => ["node"],
+            description => "Pings AMOC nodes from master node",
+            produces => ["application/json"]
+           }
+     },
     [trails:trail("/nodes", ?MODULE, [], Metadata)].
 
 -spec init(tuple(), cowboy_req:req(), state()) ->
@@ -47,4 +47,8 @@ content_types_provided(Req, State) ->
                      {jsx:json_text(), cowboy_req:req(), state()}.
 to_json(Req, State) ->
     Nodes = amoc_dist:ping_nodes(),
-    {jsx:encode([{<<"nodes">>, Nodes}]), Req, State}.
+    ResponseList = lists:map(
+                       fun({X, ping}) -> {X, up};
+                          ({X, pang}) -> {X, down}
+                        end, Nodes),
+    {jsx:encode([{<<"nodes">>, ResponseList}]), Req, State}.

--- a/src/amoc_dist.erl
+++ b/src/amoc_dist.erl
@@ -21,10 +21,10 @@ start_nodes() ->
     Path = amoc_config:get(path, "/usr"),
     start_nodes(Hosts, Path).
 
--spec ping_nodes() -> [pong|pang].
+-spec ping_nodes() -> [{string(), pong|pang}].
 ping_nodes() ->
     Hosts = amoc_config:get(hosts, []),
-    [ ping_node(amoc_slave:node_name(Host)) || Host <- Hosts ].
+    [ {Host, ping_node(amoc_slave:node_name(Host))} || Host <- Hosts ].
 
 -spec do(amoc:scenario(), amoc_scenario:user_id(), amoc_scenario:user_id()) ->
     [any()].


### PR DESCRIPTION
Now when we do `GET /nodes` we invoke function `amoc_dist:ping_nodes()`, and on response we get:
`
{
    "nodes":
    {
        nodeName1: "up" | "down",
        nodeName2:  "up" | "down"
        ...
}
`