### PR TITLE
Include scenario sources in release

### DIFF
--- a/relx.config
+++ b/relx.config
@@ -25,3 +25,7 @@
 {sys_config, "priv/app.config"}.
 {include_src, false}.
 {vm_args, "./priv/vm.args"}.
+{overlay, [
+           {mkdir, "ebin"},
+           {copy, "scenarios", "{{output_dir}}/scenarios"}
+    ]}.

--- a/relx.config
+++ b/relx.config
@@ -26,6 +26,6 @@
 {include_src, false}.
 {vm_args, "./priv/vm.args"}.
 {overlay, [
-           {mkdir, "ebin"},
+           {mkdir, "scenarios_ebin"},
            {copy, "scenarios", "{{output_dir}}/scenarios"}
     ]}.

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ if [ "$#" -ne 3 ]; then
     exit 1
 fi
 
-./rebar compile && erl -config priv/app -env ERL_FULLSWEEP_AFTER 2 -pa ./deps/*/ebin ./ebin -s amoc do $1 $2 $3
+./rebar compile && erl -config priv/app -env ERL_FULLSWEEP_AFTER 2 -pa ./deps/*/ebin ./ebin ./scenarios_ebin -s amoc do $1 $2 $3

--- a/src/amoc_api_scenarios_handler.erl
+++ b/src/amoc_api_scenarios_handler.erl
@@ -119,7 +119,7 @@ get_vars_from_body(Req) ->
 -spec compile_and_load_scenario(binary(), string()) ->
     ok | error.
 compile_and_load_scenario(BinModuleName, ScenarioPath) ->
-    case compile:file(ScenarioPath, [{outdir, ebin}]) of
+    case compile:file(ScenarioPath, [{outdir, scenarios_ebin}]) of
         {ok, _} ->
             Module = erlang:binary_to_atom(BinModuleName, utf8),
             code:load_file(Module),

--- a/test/amoc_api_scenarios_handler_SUITE.erl
+++ b/test/amoc_api_scenarios_handler_SUITE.erl
@@ -5,6 +5,7 @@
 
 -define(SCENARIOS_URL_S, "/scenarios").
 -define(SCENARIOS_DIR_S, "scenarios").
+-define(SCENARIOS_EBIN_DIR_S, "scenarios_ebin").
 -define(SAMPLE_SCENARIO_S, "sample_test.erl").
 -define(SAMPLE_SCENARIO_BEAM_S, "sample_test.beam").
 -define(SAMPLE_SCENARIO_A, sample_test).
@@ -29,22 +30,22 @@ all() ->
 
 
 init_per_testcase(_, Config) ->
-    ok = file:make_dir("ebin"),
+    ok = file:make_dir(?SCENARIOS_EBIN_DIR_S),
     ok = file:make_dir(?SCENARIOS_DIR_S),
     {ok, _} = application:ensure_all_started(inets),
     {ok, _} = application:ensure_all_started(amoc),
     Config.
 
 end_per_testcase(post_scenarios_returns_200_and_when_scenario_valid, _Config) ->
-    ok = file:delete(filename:join(["ebin",
+    ok = file:delete(filename:join([?SCENARIOS_EBIN_DIR_S,
                                     ?SAMPLE_SCENARIO_BEAM_S])),
     ok = file:delete(filename:join([?SCENARIOS_DIR_S,
                                     ?SAMPLE_SCENARIO_S])),
-    ok = file:del_dir("ebin"),
+    ok = file:del_dir(?SCENARIOS_EBIN_DIR_S),
     ok = file:del_dir(?SCENARIOS_DIR_S);
 
 end_per_testcase(_, _Config) ->
-    ok = file:del_dir("ebin"),
+    ok = file:del_dir(?SCENARIOS_EBIN_DIR_S),
     ok = file:del_dir(?SCENARIOS_DIR_S).
 
 get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
@@ -98,7 +99,7 @@ post_scenarios_returns_200_and_when_scenario_valid(Config) ->
     {CodeHttp, Body} = post_request(URL, RequestBody),
     ScenarioFileSource = filename:join([?SCENARIOS_DIR_S,
                                         ?SAMPLE_SCENARIO_S]),
-    ScenarioFileBeam = filename:join(["ebin",
+    ScenarioFileBeam = filename:join([?SCENARIOS_EBIN_DIR_S,
                                       ?SAMPLE_SCENARIO_BEAM_S]),
     %% then
     ?assertEqual(200, CodeHttp),


### PR DESCRIPTION
To be able to show users source of scenario, we should include them in release. Directory "scenarios" is also used for storage scenarios uploaded by user. 