### PR TITLE
Simple api2 run scenario fix

### DIFF
--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -27,12 +27,5 @@
           {[amoc, counters, connections], spiral, []},
           {[amoc, counters, connection_failures], spiral, []}
          ]}
-  ]},
-  {lager, [
-  {handlers, [
-    {lager_console_backend, info},
-    {lager_file_backend, [{file, "error.log"}, {level, error}]},
-    {lager_file_backend, [{file, "console.log"}, {level, info}]}
-  ]}
   ]}
  ]}.

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -7,6 +7,7 @@
                   kernel,
                   stdlib,
                   lager,
+                  jiffy,
                   exometer,
                   lhttpc,
                   ssl,
@@ -26,5 +27,12 @@
           {[amoc, counters, connections], spiral, []},
           {[amoc, counters, connection_failures], spiral, []}
          ]}
+  ]},
+  {lager, [
+  {handlers, [
+    {lager_console_backend, info},
+    {lager_file_backend, [{file, "error.log"}, {level, error}]},
+    {lager_file_backend, [{file, "console.log"}, {level, info}]}
+  ]}
   ]}
  ]}.

--- a/src/amoc_api_scenario_handler.erl
+++ b/src/amoc_api_scenario_handler.erl
@@ -150,8 +150,8 @@ from_json(Req, State = #state{resource = Resource}) ->
     case get_users_from_body(Req) of
         {ok, Users, Req2} ->
             Scenario = erlang:list_to_atom(Resource),
-            _ = amoc_dist:do(Scenario, 1, Users),
-            Reply = jsx:encode([{scenario, started}]),
+            Result = amoc_dist:do(Scenario, 1, Users),
+            Reply = jsx:encode([{scenario, get_result(Result)}]),
             Req3 = cowboy_req:set_resp_body(Reply, Req2),
             {true, Req3, State};
         {error, bad_request, Req2} ->
@@ -162,6 +162,8 @@ from_json(Req, State = #state{resource = Resource}) ->
 
 
 %% internal function
+-spec get_users_from_body(cowboy_req:req()) -> {ok, term(), cowboy_req:req()} |
+        {error, bad_request, cowboy_req:req()}.
 get_users_from_body(Req) ->
     {ok, Body, Req2} = cowboy_req:body(Req),
     try
@@ -173,3 +175,14 @@ get_users_from_body(Req) ->
               {error, bad_request, Req2}
     end.
 
+-spec get_result([ok | {error, term()}]) -> started | error.
+get_result(Result) ->
+    Res = lists:all(fun(X) -> X == ok end, Result),
+    case Res of
+        true -> started;
+        false ->
+                %% Internal server error, log problems
+                Errors = lists:filter(fun(X) -> X =/= ok end, Result),
+                lager:error("Run scenario error: ~p", [Errors]),
+                error
+    end. 

--- a/src/amoc_api_scenario_handler.erl
+++ b/src/amoc_api_scenario_handler.erl
@@ -181,7 +181,6 @@ get_result(Result) ->
     case Res of
         true -> started;
         false ->
-                %% Internal server error, log problems
                 Errors = lists:filter(fun(X) -> X =/= ok end, Result),
                 lager:error("Run scenario error: ~p", [Errors]),
                 error

--- a/src/amoc_api_scenarios_handler.erl
+++ b/src/amoc_api_scenarios_handler.erl
@@ -179,8 +179,8 @@ get_vars_from_body(Req) ->
 -spec compile_and_load_scenario(binary(), string()) ->
     ok | {error, [string()], [string()]}.
 compile_and_load_scenario(BinModuleName, ScenarioPath) ->
-    case compile:file(ScenarioPath, [{outdir, scenarios_ebin}, verbose,
-        return_errors, report_errors, report_warnings]) of
+    case compile:file(ScenarioPath, [{parse_transform, lager_transform},
+        {outdir, "scenarios_ebin"}, return_errors, report_errors, verbose]) of
         {ok, _} ->
             Module = erlang:binary_to_atom(BinModuleName, utf8),
             code:add_patha("scenarios_ebin"),

--- a/src/amoc_api_scenarios_handler.erl
+++ b/src/amoc_api_scenarios_handler.erl
@@ -146,7 +146,7 @@ from_json(Req, State) ->
                              ok -> Result;
                              {error, Errors, _Warnings} ->
                                  R = io_lib:format("~p", [Errors]),
-                                 lists:flatten(R)
+                                 erlang:list_to_bitstring(lists:flatten(R))
                          end,
             Reply = jsx:encode([{compile, ResultBody}]),
             Req3 = cowboy_req:set_resp_body(Reply, Req2),

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -37,7 +37,7 @@ init_per_testcase(
   patch_scenario_returns_200_when_request_ok_and_module_exists,
   Config) ->
     ok = meck:new(amoc_dist, [unstick]),
-    Fun = fun(_,1,_) -> ok end,
+    Fun = fun(_,1,_) -> [ok] end,
     ok = meck:expect(amoc_dist, do, Fun),
     create_env(Config),
     Config;

--- a/test/amoc_api_scenarios_handler_SUITE.erl
+++ b/test/amoc_api_scenarios_handler_SUITE.erl
@@ -84,10 +84,11 @@ post_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Con
     ?assertNot(filelib:is_regular(ScenarioFileSource)),
     ?assertEqual(200, CodeHttp),
     ?assertEqual([{<<"compile">>, 
-                "[{\"scenarios/sample_test.erl\",[{1,erl_parse," ++
-                "[\"syntax error before: \",[]]}]},\n " ++ 
-                "{\"scenarios/sample_test.erl\",[{1,erl_lint,undefined_module}" ++
-                "]}]"}],
+                   <<"[{\"scenarios/sample_test.erl\",[{1,erl_parse,"
+                     "[\"syntax error before: \",[]]}]},\n "
+                     "{\"scenarios/sample_test.erl\",["
+                     "{1,erl_lint,undefined_module}"
+                     "]}]">>}],
                  Body).
 
 post_scenarios_returns_200_and_when_scenario_valid(Config) ->


### PR DESCRIPTION
Previously we have some bugs and problems with running uploaded scenario:
* there was no information that scenario is not started
* scenario crashes if it uses lager which need special compile flag during compilation
* if we compiled scenario then we couldn't load it because in one line we provide directory name as atom, not a string and we couldn't use scenario later.