### PR TITLE
Replace jsx with jiffy in amoc

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,6 @@
             {mochijson2, ".*", {git, "git://github.com/bjnortier/mochijson2.git", {branch, "master"}}},
             {proper, ".*", {git, "git://github.com/manopapad/proper.git", {branch, "master"}}},
             {recon, ".*", {git, "https://github.com/ferd/recon.git", "2.2.1"}},
-            {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", "1.0.4"}},
-            {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", "v2.8.0"}}
+            {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", "1.0.4"}}
            ]}.
 

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -7,10 +7,10 @@
                   kernel,
                   stdlib,
                   lager,
+                  jiffy,
                   exometer,
                   lhttpc,
                   ssl,
-                  jsx,
                   trails,
                   cowboy,
                   cowboy_swagger

--- a/src/amoc_api_node_handler.erl
+++ b/src/amoc_api_node_handler.erl
@@ -60,11 +60,11 @@ content_types_provided(Req, State) ->
     {[{<<"application/json">>, to_json}], Req, State}.
 
 -spec to_json(cowboy_req:req(), state()) ->
-                     {jsx:json_text(), cowboy_req:req(), state()}.
+                     {iolist(), cowboy_req:req(), state()}.
 to_json(Req, State) ->
     Nodes = amoc_dist:ping_nodes(),
     ResponseList = lists:map(
                        fun({X, pong}) -> {X, up};
                           ({X, pang}) -> {X, down}
                         end, Nodes),
-    {jsx:encode([{<<"nodes">>, ResponseList}]), Req, State}.
+    {jiffy:encode({[{<<"nodes">>, {ResponseList}}]}), Req, State}.

--- a/src/amoc_api_scenario_handler.erl
+++ b/src/amoc_api_scenario_handler.erl
@@ -137,10 +137,10 @@ resource_exists(Req, State = #state{resource = Resource}) ->
 %% Request processing functions
 
 -spec to_json(cowboy_req:req(), state()) -> 
-    {jsx:json_text(), cowboy_req:req(), state()}.
+    {iolist(), cowboy_req:req(), state()}.
 to_json(Req0, State = #state{resource = Resource}) ->
     Status = amoc_dist:test_status(erlang:list_to_atom(Resource)),
-    Reply = jsx:encode([{scenario_status, Status}]),
+    Reply = jiffy:encode({[{scenario_status, Status}]}),
     {Reply, Req0, State}.
 
 
@@ -151,11 +151,11 @@ from_json(Req, State = #state{resource = Resource}) ->
         {ok, Users, Req2} ->
             Scenario = erlang:list_to_atom(Resource),
             _ = amoc_dist:do(Scenario, 1, Users),
-            Reply = jsx:encode([{scenario, started}]),
+            Reply = jiffy:encode({[{scenario, started}]}),
             Req3 = cowboy_req:set_resp_body(Reply, Req2),
             {true, Req3, State};
         {error, bad_request, Req2} ->
-            Reply = jsx:encode([{scenario, bad_request}]),
+            Reply = jiffy:encode({[{scenario, bad_request}]}),
             Req3 = cowboy_req:set_resp_body(Reply, Req2),
             {false, Req3, State}
     end.
@@ -165,7 +165,7 @@ from_json(Req, State = #state{resource = Resource}) ->
 get_users_from_body(Req) ->
     {ok, Body, Req2} = cowboy_req:body(Req),
     try
-        JSON = jsx:decode(Body),
+        {JSON} = jiffy:decode(Body),
         Users = proplists:get_value(<<"users">>, JSON),
         true = is_integer(Users),
         {ok, Users, Req2}

--- a/src/amoc_api_status_handler.erl
+++ b/src/amoc_api_status_handler.erl
@@ -61,10 +61,10 @@ content_types_provided(Req, State) ->
     {[{<<"application/json">>, to_json}], Req, State}.
 
 -spec to_json(cowboy_req:req(), state()) ->
-    {binary(), cowboy_req:req(), state()}.
+    {iolist(), cowboy_req:req(), state()}.
 to_json(Req0, State) ->
     Status = get_status(),
-    StatusJson = jsx:encode([{node_status, Status}]),
+    StatusJson = jiffy:encode({[{node_status, Status}]}),
     {StatusJson, Req0, State}.
     
 -spec get_status() -> up | down.

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -27,7 +27,7 @@ returns_empty_list_when_amoc_up(_Config) ->
     {CodeHttp,JSON} = send_request(),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"nodes">>, []}], JSON).
+    ?assertMatch({[{<<"nodes">>, {[]}}]}, JSON).
 
 returns_nodes_list_when_amoc_up(_Config) ->
     %% given
@@ -38,7 +38,7 @@ returns_nodes_list_when_amoc_up(_Config) ->
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch(
-        [{<<"nodes">>, [{<<"test1">>, <<"up">>}, {<<"test2">>, <<"down">>}]}],
+        {[{<<"nodes">>, {[{<<"test1">>, <<"up">>}, {<<"test2">>, <<"down">>}]}}]},
         JSON),
     %% cleanup
     clean_nodes().
@@ -55,11 +55,11 @@ get_url() ->
     Port = amoc_config:get(api_port, 4000),
     "http://localhost:" ++ erlang:integer_to_list(Port).
 
--spec send_request() -> {integer(), jsx:json_term()}.
+-spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
 send_request() ->
     Result = httpc:request(get_url() ++ "/nodes"),
     {ok, {{_HttpVsn, CodeHttp, _Status}, _, Body}} = Result,
-    BodyErl = jsx:decode(erlang:list_to_bitstring(Body)),
+    BodyErl = jiffy:decode(erlang:list_to_bitstring(Body)),
     {CodeHttp, BodyErl}.
 
 -spec given_prepared_nodes() -> ok.

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -84,7 +84,7 @@ get_scenario_status_returns_running_when_scenario_is_running(_Config) ->
     {CodeHttp, Body} = get_request(URL),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"scenario_status">>, <<"running">>}], Body),
+    ?assertMatch({[{<<"scenario_status">>, <<"running">>}]}, Body),
     %% cleanup
     cleanup_amoc_dist().
 
@@ -96,7 +96,7 @@ get_scenario_status_returns_finished_when_scenario_is_ended(_Config) ->
     {CodeHttp, Body} = get_request(URL),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"scenario_status">>, <<"finished">>}], Body),
+    ?assertMatch({[{<<"scenario_status">>, <<"finished">>}]}, Body),
     %% cleanup
     cleanup_amoc_dist().
 
@@ -108,14 +108,14 @@ get_scenario_status_returns_loaded_when_scenario_is_not_running(_Config) ->
     {CodeHttp, Body} = get_request(URL),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"scenario_status">>, <<"loaded">>}], Body),
+    ?assertMatch({[{<<"scenario_status">>, <<"loaded">>}]}, Body),
     %% cleanup
     cleanup_amoc_dist().
 
 patch_scenario_returns_404_when_scenario_not_exists(_Config) ->
     %% given
     URL = get_url() ++ "/scenarios/non_existing_scenario",
-    RequestBody = jsx:encode([{users,30}]),
+    RequestBody = jiffy:encode({[{users,30}]}),
     %% when
     {CodeHttp, _Body} = patch_request(URL, RequestBody),
     %% then
@@ -125,7 +125,7 @@ patch_scenario_returns_404_when_scenario_not_exists(_Config) ->
 patch_scenario_returns_400_when_malformed_request(_Config) ->
     %% given
     URL = get_url() ++ "/scenarios/sample_test",
-    RequestBody = jsx:encode([{bad_key, bad_value}]),
+    RequestBody = jiffy:encode({[{bad_key, bad_value}]}),
     %% when
     {CodeHttp, _Body} = patch_request(URL, RequestBody),
     %% then
@@ -136,7 +136,7 @@ patch_scenario_returns_400_when_malformed_request(_Config) ->
 patch_scenario_returns_200_when_request_ok_and_module_exists(_Config) ->
     %% given
     URL = get_url() ++ "/scenarios/sample_test",
-    RequestBody = jsx:encode([{users, 10}]),
+    RequestBody = jiffy:encode({[{users, 10}]}),
     %% when
     {CodeHttp, _Body} = patch_request(URL, RequestBody),
     %% then
@@ -176,7 +176,7 @@ get_url() ->
     "http://localhost:" ++ erlang:integer_to_list(Port).
 
 -spec get_request(string()) -> 
-    {integer(), jsx:json_term()}.
+    {integer(), jiffy:jiffy_decode_result()}.
 get_request(URL) ->
     Header = [],
     HTTPOpts = [],
@@ -191,12 +191,12 @@ get_request(URL) ->
                   [] -> 
                       [];
                   _ ->
-                      jsx:decode(erlang:list_to_bitstring(Body))
+                      jiffy:decode(erlang:list_to_bitstring(Body))
               end,
     {CodeHttp, BodyErl}.
 
 -spec patch_request(string(), string()) ->
-    {integer(), jsx:json_term()}.
+    {integer(), jiffy:jiffy_decode_result()}.
 patch_request(URL, RequestBody) ->
     Header = "",
     Type = "application/json",
@@ -211,7 +211,7 @@ patch_request(URL, RequestBody) ->
                   [] -> 
                       [];
                   _ ->
-                      jsx:decode(erlang:list_to_bitstring(Body))
+                      jiffy:decode(erlang:list_to_bitstring(Body))
               end,
     {CodeHttp, BodyErl}.
 

--- a/test/amoc_api_scenarios_handler_SUITE.erl
+++ b/test/amoc_api_scenarios_handler_SUITE.erl
@@ -52,8 +52,8 @@ get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
     %% given
     URL = get_url() ++ ?SCENARIOS_URL_S,
     %% when
-    {CodeHttp, Body} = get_request(URL),
-    Scenarios = proplists:get_value(<<"scenarios">>, Body),
+    {CodeHttp, {Body}} = get_request(URL),
+    {Scenarios} = proplists:get_value(<<"scenarios">>, Body),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assert(is_list(Scenarios)).
@@ -61,21 +61,21 @@ get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
 post_scenarios_returns_400_when_malformed_request(_Config) ->
     %% given
     URL = get_url() ++ ?SCENARIOS_URL_S,
-    RequestBody = jsx:encode([{keyname_typo, ?SAMPLE_SCENARIO_A}]),
+    RequestBody = jiffy:encode({[{keyname_typo, ?SAMPLE_SCENARIO_A}]}),
     %% when
     {CodeHttp, Body} = post_request(URL, RequestBody),
     %% then
     ?assertEqual(400, CodeHttp),
-    ?assertEqual([{<<"error">>, <<"wrong_json">>}],
+    ?assertEqual({[{<<"error">>, <<"wrong_json">>}]},
                  Body).
 
 post_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Config) ->
     %% given
     URL = get_url() ++ ?SCENARIOS_URL_S,
-    RequestBody = jsx:encode([
+    RequestBody = jiffy:encode({[
                               {scenario, ?SAMPLE_SCENARIO_A},
                               {module_source, invalid_source}
-                             ]),
+                              ]}),
     %% when
     {CodeHttp, Body} = post_request(URL, RequestBody),
     ScenarioFileSource = filename:join([?SCENARIOS_DIR_S,
@@ -83,11 +83,12 @@ post_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Con
     %% then
     ?assertNot(filelib:is_regular(ScenarioFileSource)),
     ?assertEqual(200, CodeHttp),
-    ?assertEqual([{<<"compile">>, 
-                "[{\"scenarios/sample_test.erl\",[{1,erl_parse," ++
-                "[\"syntax error before: \",[]]}]},\n " ++ 
-                "{\"scenarios/sample_test.erl\",[{1,erl_lint,undefined_module}" ++
-                "]}]"}],
+    ?assertEqual({[{<<"compile">>, 
+                <<"[{\"scenarios/sample_test.erl\",[{1,erl_parse,"
+                  "[\"syntax error before: \",[]]}]},\n " 
+                  "{\"scenarios/sample_test.erl\",[{1,erl_lint,"
+                  "undefined_module}"
+                  "]}]">>}]},
                  Body).
 
 post_scenarios_returns_200_and_when_scenario_valid(Config) ->
@@ -95,10 +96,10 @@ post_scenarios_returns_200_and_when_scenario_valid(Config) ->
     URL = get_url() ++ ?SCENARIOS_URL_S,
     ScenarioFile = data(Config, ?SAMPLE_SCENARIO_S),
     {ok, ScenarioContent} = file:read_file(ScenarioFile),
-    RequestBody = jsx:encode([
+    RequestBody = jiffy:encode({[
                               {scenario, ?SAMPLE_SCENARIO_A},
                               {module_source, ScenarioContent}
-                             ]),
+                               ]}),
     %% when
     {CodeHttp, Body} = post_request(URL, RequestBody),
     ScenarioFileSource = filename:join([?SCENARIOS_DIR_S,
@@ -109,7 +110,7 @@ post_scenarios_returns_200_and_when_scenario_valid(Config) ->
     ?assertEqual(200, CodeHttp),
     ?assert(filelib:is_regular(ScenarioFileSource)),
     ?assert(filelib:is_regular(ScenarioFileBeam)),
-    ?assertEqual([{<<"compile">>, <<"ok">>}],
+    ?assertEqual({[{<<"compile">>, <<"ok">>}]},
                  Body).
 
 %% Helpers
@@ -124,7 +125,7 @@ get_url() ->
     "http://localhost:" ++ erlang:integer_to_list(Port).
 
 -spec get_request(string()) -> 
-    {integer(), jsx:json_term()}.
+    {integer(), jiffy:jiffy_decode_result()}.
 get_request(URL) ->
     Header = [],
     HTTPOpts = [],
@@ -139,12 +140,12 @@ get_request(URL) ->
                   [] -> 
                       [];
                   _ ->
-                      jsx:decode(erlang:list_to_bitstring(Body))
+                      jiffy:decode(erlang:list_to_bitstring(Body))
               end,
     {CodeHttp, BodyErl}.
 
 -spec post_request(string(), string()) ->
-    {integer(), jsx:json_term()}.
+    {integer(), jiffy:jiffy_decode_result()}.
 post_request(URL, RequestBody) ->
     Header = "",
     Type = "application/json",
@@ -159,7 +160,6 @@ post_request(URL, RequestBody) ->
                   [] -> 
                       [];
                   _ ->
-                      jsx:decode(erlang:list_to_bitstring(Body))
+                      jiffy:decode(erlang:list_to_bitstring(Body))
               end,
     {CodeHttp, BodyErl}.
-

--- a/test/amoc_api_status_handler_SUITE.erl
+++ b/test/amoc_api_status_handler_SUITE.erl
@@ -39,7 +39,7 @@ returns_up_when_amoc_up_online(_Config) ->
     {CodeHttp, Body} = send_request(),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"node_status">>, <<"up">>}], Body).
+    ?assertMatch({[{<<"node_status">>, <<"up">>}]}, Body).
 
 
 returns_down_when_api_up_and_amoc_down_offline(_Config) ->
@@ -57,7 +57,7 @@ returns_down_when_api_up_and_amoc_down_online(_Config) ->
     {CodeHttp, Body} = send_request(),
     %% then
     ?assertEqual(200, CodeHttp),
-    ?assertMatch([{<<"node_status">>, <<"down">>}], Body).
+    ?assertMatch({[{<<"node_status">>, <<"down">>}]}, Body).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% HELPERS
@@ -75,9 +75,9 @@ get_url() ->
     Port = amoc_config:get(api_port, 4000),
     "http://localhost:" ++ erlang:integer_to_list(Port).
 
--spec send_request() -> {integer(), jsx:json_term()}.
+-spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
 send_request() ->
     Result = httpc:request(get_url() ++ "/status"),
     {ok, {{_HttpVsn, CodeHttp, _Status}, _, Body}} = Result, 
-    BodyErl = jsx:decode(erlang:list_to_bitstring(Body)),
+    BodyErl = jiffy:decode(erlang:list_to_bitstring(Body)),
     {CodeHttp, BodyErl}.


### PR DESCRIPTION
Previously we had jiffy and jsx. We don't need two JSON parsers, and we need to have jiffy, so now we use only jiffy in code.