### PR TITLE
Replace httpc with fusco

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,7 @@
             {mochijson2, ".*", {git, "git://github.com/bjnortier/mochijson2.git", {branch, "master"}}},
             {proper, ".*", {git, "git://github.com/manopapad/proper.git", {branch, "master"}}},
             {recon, ".*", {git, "https://github.com/ferd/recon.git", "2.2.1"}},
-            {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", "1.0.4"}}
+            {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", "1.0.4"}},
+            {fusco, ".*", {git, "https://github.com/esl/fusco.git"}}
            ]}.
 

--- a/scenarios/mongoose_pubsub_docker.erl
+++ b/scenarios/mongoose_pubsub_docker.erl
@@ -50,7 +50,18 @@ start(MyId) ->
 
 work_as_publisher(MyId, Client) ->
     create_pubsub_node(Client, pubsub_node(MyId)),
-    publish_items_forever(Client, MyId, pubsub_node(MyId), 1).
+    case MyId rem 3 of
+        0 -> publish_many_items(Client, MyId, pubsub_node(MyId), 1, 20000);
+        _ -> publish_items_forever(Client, MyId, pubsub_node(MyId), 1)
+    end.
+
+publish_many_items(_, _, _, _, 0) -> ok;
+
+publish_many_items(Client, MyId, Node, ItemId, Count) ->
+    timer:sleep(?DELAY_BETWEEN_MESSAGES),
+    lager:debug("Publisher ~p publishing item ~p.", [MyId, ItemId]),
+    publish(Client, integer_to_binary(ItemId), Node),
+    publish_many_items(Client, MyId, Node, ItemId + 1, Count - 1).
 
 publish_items_forever(Client, MyId, Node, ItemId) ->
     timer:sleep(?DELAY_BETWEEN_MESSAGES),

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -13,7 +13,8 @@
                   ssl,
                   trails,
                   cowboy,
-                  cowboy_swagger
+                  cowboy_swagger,
+                  fusco
                  ]},
   {mod, { amoc_app, []}},
   {env, [{repeat_interval, 60000},

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -13,8 +13,7 @@
                   ssl,
                   trails,
                   cowboy,
-                  cowboy_swagger,
-                  fusco
+                  cowboy_swagger
                  ]},
   {mod, { amoc_app, []}},
   {env, [{repeat_interval, 60000},

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -2,7 +2,6 @@
 
 -export([get/1, get/2, post/2, post/3, patch/2, patch/3]).
 
-
 -spec get(string()) -> {integer(), jiffy:jiffy_decode_result()}. 
 get(Path) -> get(get_url(), Path).
 
@@ -18,7 +17,6 @@ post(Path, Body) -> post(get_url(), Path, Body).
     {integer(), jiffy:jiffy_decode_result()}.
 post(BaseUrl, Path, Body) -> 
     request(BaseUrl, erlang:list_to_bitstring(Path), <<"POST">>, Body).
-
 
 -spec patch(string(), binary()) ->
     {integer(), jiffy:jiffy_decode_result()}.
@@ -46,6 +44,7 @@ request(BaseUrl, Path, Method, RequestBody) ->
                 <<"">> -> [];
                 _ -> jiffy:decode(Body)
               end,
+    fusco:disconnect(Client),
     {erlang:binary_to_integer(CodeHttpBin), BodyErl}.
 
 -spec get_url() -> string().

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -1,0 +1,54 @@
+-module(amoc_api_helper).
+
+-export([get/1, get/2, post/2, post/3, patch/2, patch/3]).
+
+
+-spec get(string()) -> {integer(), jiffy:jiffy_decode_result()}. 
+get(Path) -> get(get_url(), Path).
+
+-spec get(string(), string()) -> {integer(), jiffy:jiffy_decode_result()}. 
+get(BaseUrl, Path) -> 
+    request(BaseUrl, erlang:list_to_bitstring(Path), <<"GET">>).
+
+-spec post(string(), binary()) -> 
+    {integer(), jiffy:jiffy_decode_result()}.
+post(Path, Body) -> post(get_url(), Path, Body).
+
+-spec post(string(), string(), binary()) -> 
+    {integer(), jiffy:jiffy_decode_result()}.
+post(BaseUrl, Path, Body) -> 
+    request(BaseUrl, erlang:list_to_bitstring(Path), <<"POST">>, Body).
+
+
+-spec patch(string(), binary()) ->
+    {integer(), jiffy:jiffy_decode_result()}.
+patch(Path, Body) -> patch(get_url(), Path, Body). 
+
+-spec patch(string(), string(), binary()) ->
+    {integer(), jiffy:jiffy_decode_result()}.
+patch(BaseUrl, Path, Body) ->
+    request(BaseUrl, erlang:list_to_bitstring(Path), <<"PATCH">>, Body).
+
+-spec request(string(), binary(), binary()) -> 
+    {integer(), jiffy:jiffy_decode_result()}.
+request(BaseUrl, Path, Method) -> request(BaseUrl, Path, Method, <<"">>).
+
+-spec request(string(), binary(), binary(), binary()) ->
+    {integer(), jiffy:jiffy_decode_result()}.
+request(BaseUrl, Path, Method, RequestBody) ->
+    {ok, Client} = fusco:start(BaseUrl, []),
+    {ok, Result} = fusco:request(
+                    Client, Path, Method,
+                    [{<<"content-type">>, <<"application/json">>}],
+                    RequestBody, 5000),
+    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
+    BodyErl = case Body of
+                <<"">> -> [];
+                _ -> jiffy:decode(Body)
+              end,
+    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.
+
+-spec get_url() -> string().
+get_url() ->
+    Port = amoc_config:get(api_port, 4000),
+    "http://localhost:" ++ erlang:integer_to_list(Port).

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -7,6 +7,8 @@
 -export([returns_empty_list_when_amoc_up/1,
          returns_nodes_list_when_amoc_up/1]).
 
+-define(PATH, "/nodes").
+
 all() ->
     [returns_empty_list_when_amoc_up,
      returns_nodes_list_when_amoc_up].
@@ -24,7 +26,7 @@ returns_empty_list_when_amoc_up(_Config) ->
     %% given
     given_applications_started(),
     %% when
-    {CodeHttp,JSON} = send_request(),
+    {CodeHttp,JSON} = amoc_api_helper:get(?PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"nodes">>, {[]}}]}, JSON).
@@ -34,7 +36,7 @@ returns_nodes_list_when_amoc_up(_Config) ->
     given_applications_started(),
     given_prepared_nodes(),
     %% when
-    {CodeHttp, JSON} = send_request(),
+    {CodeHttp, JSON} = amoc_api_helper:get(?PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch(
@@ -49,20 +51,6 @@ returns_nodes_list_when_amoc_up(_Config) ->
 -spec given_applications_started() -> {ok, [atom()]} | {error, term()}.
 given_applications_started() ->
     application:ensure_all_started(amoc).
-
--spec get_url() -> string().
-get_url() ->
-    Port = amoc_config:get(api_port, 4000),
-    "http://localhost:" ++ erlang:integer_to_list(Port).
-
--spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
-send_request() ->
-    {ok, Client} = fusco:start(get_url(), []),
-    {ok, Result} = fusco:request(
-                    Client, <<"/nodes">>, <<"GET">>, [] , [], 5000),
-    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
-    BodyErl = jiffy:decode(Body),
-    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.
 
 -spec given_prepared_nodes() -> ok.
 given_prepared_nodes() ->

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -57,10 +57,12 @@ get_url() ->
 
 -spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
 send_request() ->
-    Result = httpc:request(get_url() ++ "/nodes"),
-    {ok, {{_HttpVsn, CodeHttp, _Status}, _, Body}} = Result,
-    BodyErl = jiffy:decode(erlang:list_to_bitstring(Body)),
-    {CodeHttp, BodyErl}.
+    {ok, Client} = fusco:start(get_url(), []),
+    {ok, Result} = fusco:request(
+                    Client, <<"/nodes">>, <<"GET">>, [] , [], 5000),
+    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
+    BodyErl = jiffy:decode(Body),
+    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.
 
 -spec given_prepared_nodes() -> ok.
 given_prepared_nodes() ->

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -61,7 +61,7 @@ get_scenario_status_returns_200_when_scenario_exists(_Config) ->
     %% given
     given_amoc_dist_mocked_with_test_status(true),
     %% when
-    {CodeHttp, _Body} = get_request(?SAMPLE_GOOD_SCENARIO_PATH),
+    {CodeHttp, _Body} = amoc_api_helper:get(?SAMPLE_GOOD_SCENARIO_PATH),
     %% then
     %% Maybe check Body, as answer format will be ready
     ?assertEqual(200, CodeHttp),
@@ -70,7 +70,7 @@ get_scenario_status_returns_200_when_scenario_exists(_Config) ->
 
 get_scenario_status_returns_404_when_scenario_not_exists(_Config) ->
     %% when
-    {CodeHttp, _Body} = get_request(?SAMPLE_BAD_SCENARIO_PATH),
+    {CodeHttp, _Body} = amoc_api_helper:get(?SAMPLE_BAD_SCENARIO_PATH),
     %% then
     %% Maybe check Body, as answer format will be ready
     ?assertEqual(404, CodeHttp).
@@ -79,7 +79,7 @@ get_scenario_status_returns_running_when_scenario_is_running(_Config) ->
     %% given
     given_amoc_dist_mocked_with_test_status(running),
     %% when
-    {CodeHttp, Body} = get_request(?SAMPLE_GOOD_SCENARIO_PATH),
+    {CodeHttp, Body} = amoc_api_helper:get(?SAMPLE_GOOD_SCENARIO_PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"scenario_status">>, <<"running">>}]}, Body),
@@ -90,7 +90,7 @@ get_scenario_status_returns_finished_when_scenario_is_ended(_Config) ->
     %% given
     given_amoc_dist_mocked_with_test_status(finished),
     %% when
-    {CodeHttp, Body} = get_request(?SAMPLE_GOOD_SCENARIO_PATH),
+    {CodeHttp, Body} = amoc_api_helper:get(?SAMPLE_GOOD_SCENARIO_PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"scenario_status">>, <<"finished">>}]}, Body),
@@ -101,7 +101,7 @@ get_scenario_status_returns_loaded_when_scenario_is_not_running(_Config) ->
     %% given
     given_amoc_dist_mocked_with_test_status(loaded),
     %% when
-    {CodeHttp, Body} = get_request(?SAMPLE_GOOD_SCENARIO_PATH),
+    {CodeHttp, Body} = amoc_api_helper:get(?SAMPLE_GOOD_SCENARIO_PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"scenario_status">>, <<"loaded">>}]}, Body),
@@ -112,7 +112,8 @@ patch_scenario_returns_404_when_scenario_not_exists(_Config) ->
     %% given
     RequestBody = jiffy:encode({[{users,30}]}),
     %% when
-    {CodeHttp, _Body} = patch_request(?SAMPLE_BAD_SCENARIO_PATH, RequestBody),
+    {CodeHttp, _Body} = amoc_api_helper:patch(
+                            ?SAMPLE_BAD_SCENARIO_PATH, RequestBody),
     %% then
     %% Maybe check Body, as answer format will be ready
     ?assertEqual(404, CodeHttp).
@@ -121,7 +122,8 @@ patch_scenario_returns_400_when_malformed_request(_Config) ->
     %% given
     RequestBody = jiffy:encode({[{bad_key, bad_value}]}),
     %% when
-    {CodeHttp, _Body} = patch_request(?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
+    {CodeHttp, _Body} = amoc_api_helper:patch(
+                            ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
     %% then
     %% Maybe check Body, as answer format will be ready
     ?assertEqual(400, CodeHttp).
@@ -131,7 +133,8 @@ patch_scenario_returns_200_when_request_ok_and_module_exists(_Config) ->
     %% given
     RequestBody = jiffy:encode({[{users, 10}]}),
     %% when
-    {CodeHttp, _Body} = patch_request(?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
+    {CodeHttp, _Body} = amoc_api_helper:patch(
+                            ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
     %% then
     %% Maybe check Body, as answer format will be ready
     meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
@@ -162,42 +165,6 @@ copy(Src, Dst) ->
 data(Config, Path) ->
     Dir = proplists:get_value(data_dir, Config),
     filename:join([Dir, Path]).
-
--spec get_url() -> string().
-get_url() ->
-    Port = amoc_config:get(api_port, 4000),
-    "http://localhost:" ++ erlang:integer_to_list(Port).
-
--spec get_request(string()) -> 
-    {integer(), jiffy:jiffy_decode_result()}.
-get_request(Path) ->
-    request(get, Path).
-
--spec patch_request(string(), string()) ->
-    {integer(), jiffy:jiffy_decode_result()}.
-patch_request(Path, RequestBody) ->
-    request(<<"PATCH">>, Path, RequestBody).
-
--spec request(get, string()) ->
-    {integer(), jiffy:jiffy_decode_result()}.
-request(get, Path) ->
-    request(<<"GET">>, Path, []).
-
--spec request(binary(), string(), string()) ->
-    {integer(), jiffy:jiffy_decode_result()}.
-request(Method, Path, RequestBody) ->
-    {ok, Client} = fusco:start(get_url(), []),
-    BinPath = erlang:list_to_bitstring(Path),
-    {ok, Result} = fusco:request(
-                    Client, BinPath, Method, 
-                    [{<<"content-type">>,<<"application/json">>}],
-                    RequestBody, 5000),
-    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
-    BodyErl = case Body of
-                <<"">> -> [];
-                _ -> jiffy:decode(Body)
-              end,
-    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.
 
 -spec given_amoc_dist_mocked_with_test_status(
         amoc_controller:scenario_status()) -> ok.

--- a/test/amoc_api_scenarios_handler_SUITE.erl
+++ b/test/amoc_api_scenarios_handler_SUITE.erl
@@ -49,10 +49,8 @@ end_per_testcase(_, _Config) ->
     ok = file:del_dir(?SCENARIOS_DIR_S).
 
 get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
-    %% given
-    URL = get_url() ++ ?SCENARIOS_URL_S,
     %% when
-    {CodeHttp, {Body}} = get_request(URL),
+    {CodeHttp, {Body}} = get_request(?SCENARIOS_URL_S),
     {Scenarios} = proplists:get_value(<<"scenarios">>, Body),
     %% then
     ?assertEqual(200, CodeHttp),
@@ -60,10 +58,9 @@ get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
 
 post_scenarios_returns_400_when_malformed_request(_Config) ->
     %% given
-    URL = get_url() ++ ?SCENARIOS_URL_S,
     RequestBody = jiffy:encode({[{keyname_typo, ?SAMPLE_SCENARIO_A}]}),
     %% when
-    {CodeHttp, Body} = post_request(URL, RequestBody),
+    {CodeHttp, Body} = post_request(?SCENARIOS_URL_S, RequestBody),
     %% then
     ?assertEqual(400, CodeHttp),
     ?assertEqual({[{<<"error">>, <<"wrong_json">>}]},
@@ -71,13 +68,12 @@ post_scenarios_returns_400_when_malformed_request(_Config) ->
 
 post_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Config) ->
     %% given
-    URL = get_url() ++ ?SCENARIOS_URL_S,
     RequestBody = jiffy:encode({[
                               {scenario, ?SAMPLE_SCENARIO_A},
                               {module_source, invalid_source}
                               ]}),
     %% when
-    {CodeHttp, Body} = post_request(URL, RequestBody),
+    {CodeHttp, Body} = post_request(?SCENARIOS_URL_S, RequestBody),
     ScenarioFileSource = filename:join([?SCENARIOS_DIR_S,
                                         ?SAMPLE_SCENARIO_S]),
     %% then
@@ -93,7 +89,6 @@ post_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Con
 
 post_scenarios_returns_200_and_when_scenario_valid(Config) ->
     %% given
-    URL = get_url() ++ ?SCENARIOS_URL_S,
     ScenarioFile = data(Config, ?SAMPLE_SCENARIO_S),
     {ok, ScenarioContent} = file:read_file(ScenarioFile),
     RequestBody = jiffy:encode({[
@@ -101,7 +96,7 @@ post_scenarios_returns_200_and_when_scenario_valid(Config) ->
                               {module_source, ScenarioContent}
                                ]}),
     %% when
-    {CodeHttp, Body} = post_request(URL, RequestBody),
+    {CodeHttp, Body} = post_request(?SCENARIOS_URL_S, RequestBody),
     ScenarioFileSource = filename:join([?SCENARIOS_DIR_S,
                                         ?SAMPLE_SCENARIO_S]),
     ScenarioFileBeam = filename:join([?SCENARIOS_EBIN_DIR_S,
@@ -126,40 +121,31 @@ get_url() ->
 
 -spec get_request(string()) -> 
     {integer(), jiffy:jiffy_decode_result()}.
-get_request(URL) ->
-    Header = [],
-    HTTPOpts = [],
-    Opts = [],
-    Result = httpc:request(get,
-                           {URL, Header},
-                           HTTPOpts,
-                           Opts),
-
-    {ok, {{_HttpVsn, CodeHttp, _Status}, _, Body}} = Result,
-    BodyErl = case Body of
-                  [] -> 
-                      [];
-                  _ ->
-                      jiffy:decode(erlang:list_to_bitstring(Body))
-              end,
-    {CodeHttp, BodyErl}.
+get_request(Path) ->
+    request(get, Path).
 
 -spec post_request(string(), string()) ->
     {integer(), jiffy:jiffy_decode_result()}.
-post_request(URL, RequestBody) ->
-    Header = "",
-    Type = "application/json",
-    HTTPOpts = [],
-    Opts = [],
-    Result = httpc:request(post,
-                           {URL, Header, Type, RequestBody},
-                           HTTPOpts,
-                           Opts),
-    {ok, {{_HttpVsn, CodeHttp, _Status},_, Body}} = Result, 
+post_request(Path, RequestBody) ->
+    request(<<"POST">>, Path, RequestBody).
+
+-spec request(get, string()) ->
+    {integer(), jiffy:jiffy_decode_result()}.
+request(get, Path) ->
+    request(<<"GET">>, Path, []).
+
+-spec request(binary, string(), string()) ->
+    {integer(), jiffy:jiffy_decode_result()}.
+request(Method, Path, RequestBody) ->
+    {ok, Client} = fusco:start(get_url(), []),
+    BinPath = erlang:list_to_bitstring(Path),
+    {ok, Result} = fusco:request(
+                    Client, BinPath, Method, 
+                    [{<<"content-type">>,<<"application/json">>}], 
+                    RequestBody, 5000),
+    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
     BodyErl = case Body of
-                  [] -> 
-                      [];
-                  _ ->
-                      jiffy:decode(erlang:list_to_bitstring(Body))
+                <<"">> -> [];
+                _ -> jiffy:decode(Body)
               end,
-    {CodeHttp, BodyErl}.
+    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.    

--- a/test/amoc_api_status_handler_SUITE.erl
+++ b/test/amoc_api_status_handler_SUITE.erl
@@ -77,7 +77,9 @@ get_url() ->
 
 -spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
 send_request() ->
-    Result = httpc:request(get_url() ++ "/status"),
-    {ok, {{_HttpVsn, CodeHttp, _Status}, _, Body}} = Result, 
-    BodyErl = jiffy:decode(erlang:list_to_bitstring(Body)),
-    {CodeHttp, BodyErl}.
+    {ok, Client} = fusco:start(get_url(), []),
+    {ok, Result} = fusco:request(
+                    Client, <<"/status">>, <<"GET">>, [] , [], 5000),
+    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
+    BodyErl = jiffy:decode(Body),
+    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.

--- a/test/amoc_api_status_handler_SUITE.erl
+++ b/test/amoc_api_status_handler_SUITE.erl
@@ -9,6 +9,8 @@
          returns_down_when_api_up_and_amoc_down_offline/1,
          returns_down_when_api_up_and_amoc_down_online/1]).
 
+-define(PATH, "/status").
+
 all() ->
     [returns_up_when_amoc_up_offline,
      returns_up_when_amoc_up_online,
@@ -36,7 +38,7 @@ returns_up_when_amoc_up_online(_Config) ->
     %% given
     given_applications_started(),
     %% when
-    {CodeHttp, Body} = send_request(),
+    {CodeHttp, Body} = amoc_api_helper:get(?PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"node_status">>, <<"up">>}]}, Body).
@@ -54,7 +56,7 @@ returns_down_when_api_up_and_amoc_down_online(_Config) ->
     %% given
     given_http_api_started(),
     %% when
-    {CodeHttp, Body} = send_request(),
+    {CodeHttp, Body} = amoc_api_helper:get(?PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ?assertMatch({[{<<"node_status">>, <<"down">>}]}, Body).
@@ -69,17 +71,3 @@ given_applications_started() ->
 -spec given_http_api_started() -> {ok, pid()}.
 given_http_api_started() ->
     amoc_api:start_listener().
-
--spec get_url() -> string().
-get_url() ->
-    Port = amoc_config:get(api_port, 4000),
-    "http://localhost:" ++ erlang:integer_to_list(Port).
-
--spec send_request() -> {integer(), jiffy:jiffy_decode_result()}.
-send_request() ->
-    {ok, Client} = fusco:start(get_url(), []),
-    {ok, Result} = fusco:request(
-                    Client, <<"/status">>, <<"GET">>, [] , [], 5000),
-    {{CodeHttpBin, _}, _Headers, Body, _, _} = Result,
-    BodyErl = jiffy:decode(Body),
-    {erlang:binary_to_integer(CodeHttpBin), BodyErl}.


### PR DESCRIPTION
Instead `httpc` we want to use `fusco` only for testing purpose.
We need it also because on Travis CI we have OTP 17.5 where `httpc` do not support `PATCH` requests.