### PR TITLE
Remove Amoc building deps after creating release and expose port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,31 +1,36 @@
 FROM phusion/baseimage
 MAINTAINER Rafał Studnicki <rafal.studnicki@erlang-solutions.com>
 
-ENV AMOC_VSN simple_api2
+ENV AMOC_VSN master
 
 RUN useradd -ms /bin/bash amoc
 
-RUN apt-get update && \
-    apt-get install -y git \
-                       make \
-                       gcc \
-                       clang \
-                       libexpat1-dev \
-                       wget && \
-    wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
+RUN buildDeps=' \
+    git \
+    make \
+    gcc \
+    clang \
+    libexpat1-dev \
+    wget \
+    ' && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends $buildDeps && \
+    wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
     dpkg -i erlang-solutions_1.0_all.deb && \
     apt-get update && \
     apt-get install -y esl-erlang=1:18.3.4 && \
-    apt-get autoremove -y --purge && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    rm -rf erlang-solutions_1.0_all.deb && \
     git clone https://github.com/esl/amoc.git --branch ${AMOC_VSN} amoc_build && \
     cd amoc_build && \
     make rel && \
+    apt-get purge -y --auto-remove $buildDeps esl-erlang && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    rm -rf erlang-solutions_1.0_all.deb && \
     cp -r /amoc_build/_rel/amoc /home/amoc/amoc && \
     chown -R amoc:amoc /home/amoc/amoc && \
     rm -rf /amoc_build
+
+EXPOSE 4000
 
 RUN mkdir /etc/service/amoc
 ADD amoc.sh /etc/service/amoc/run


### PR DESCRIPTION
Before finilizing image creation we should remove building
dependencies such as clang, gcc or esl-erlang, as they are
not required for running Amoc. This makes image lighter
by around 0.5GB.

Also expose HTTP API port.

Also build image from master branch.