### PR TITLE
Fix multiple scenarios dir generation on making release:

### DIFF
--- a/relx.config
+++ b/relx.config
@@ -27,5 +27,5 @@
 {vm_args, "./priv/vm.args"}.
 {overlay, [
            {mkdir, "scenarios_ebin"},
-           {copy, "scenarios", "scenarios"}
+           {copy, "scenarios", "."}
     ]}.


### PR DESCRIPTION
It solves probably #45 . Earlier we have that line in `relx.config` because we need to include `scenarios` dir when making a release, however this attempt also works.