### PR TITLE
Allow to set graphite endpoint's port for exometer in docker container

### DIFF
--- a/docker/config/sys.config.template
+++ b/docker/config/sys.config.template
@@ -15,6 +15,7 @@
      [{exometer_report_graphite, [
                                   {prefix, "AMOC_PREFIX"},
                                   {host, "AMOC_GRAPHITE_HOST"},
+                                  {port, AMOC_GRAPHITE_PORT},
                                   {api_key, ""}
                                  ]}]},
     {subscribers, [

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,7 @@ set -x
 SYSCONFIG="/home/amoc/amoc/releases/0.9/sys.config"
 sed -e "s/AMOC_GRAPHITE_HOST/${AMOC_GRAPHITE_HOST}/" /sys.config.template > \
     ${SYSCONFIG}
+sed -i -e "s/AMOC_GRAPHITE_PORT/${AMOC_GRAPHITE_PORT}/" ${SYSCONFIG}
 sed -i -e "s/AMOC_PREFIX/${AMOC_PREFIX}/" ${SYSCONFIG}
 sed -i -e "s/AMOC_HOSTS/${AMOC_HOSTS}/" ${SYSCONFIG}
 


### PR DESCRIPTION
It would be nice to be able to set reporting endpoint's port by just passing env var into container.