### PR TITLE
Fix Docker image startup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 4000
 
 RUN mkdir /etc/service/amoc
 ADD amoc.sh /etc/service/amoc/run
-ADD config/vm.args /home/amoc/amoc/releases/0.9
+ADD config/vm.args /home/amoc/amoc/releases/0.9.0/
 ADD config/sys.config.template /
 ADD run.sh /
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage
-MAINTAINER Rafał Studnicki <rafal.studnicki@erlang-solutions.com>
+MAINTAINER Erlang Solutions <mongoose-im@erlang-solutions.com>
 
 ENV AMOC_VSN master
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-SYSCONFIG="/home/amoc/amoc/releases/0.9/sys.config"
+SYSCONFIG="/home/amoc/amoc/releases/0.9.0/sys.config"
 sed -e "s/AMOC_GRAPHITE_HOST/${AMOC_GRAPHITE_HOST}/" /sys.config.template > \
     ${SYSCONFIG}
 sed -i -e "s/AMOC_GRAPHITE_PORT/${AMOC_GRAPHITE_PORT}/" ${SYSCONFIG}


### PR DESCRIPTION
After switch to rebar3, default vm.args file was pulled from `priv/vm.args`. These vm.args contain `-name amoc` argument, so Erlang VM wanted to start with fully qualified domain name. However, in some environments, Docker containers don't know their own domain which prevented the BEAM from starting.

Docker image should have used the vm.args from `docker/config/vm.args`, but switch to rebar3 and invalid `ADD` directive prevented that file from being picked up by the release handler during startup.

This PR fixes the Dockerfile so that the correct vm.args is copied to container and used later by the release handler.