### PR TITLE
Allow to terminate a scenario when invalid

### DIFF
--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -7,6 +7,7 @@
 
 -define(SERVER, ?MODULE).
 -define(INTERARRIVAL_DEFAULT, 50).
+-define(CHECKING_INTERVAL_DEFAULT, 60*1000).
 -define(TABLE, amoc_users).
 
 -record(state, {scenario :: amoc:scenario() | undefined,
@@ -38,7 +39,8 @@
          remove/2,
          remove/3,
          users/0,
-         test_status/1]).
+         test_status/1,
+         start_scenario_checking/1]).
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
 %% ------------------------------------------------------------------
@@ -97,6 +99,10 @@ users() ->
 test_status(ScenarioName) ->
     gen_server:call(?SERVER, {status, ScenarioName}).
 
+-spec start_scenario_checking(amoc:scenario()) -> ok | skip | {error, term()}.
+start_scenario_checking(Scenario) ->
+    gen_server:call(?SERVER, {start_scenario_checking, Scenario}).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
@@ -116,6 +122,9 @@ handle_call(users, _From, State) ->
     Reply = [{count, ets:info(?TABLE, size)},
              {last, ets:last(?TABLE)}],
     {reply, {ok, Reply}, State};
+handle_call({start_scenario_checking, Scenario}, _From, State) ->
+    Reply = maybe_start_scenario_checking(Scenario),
+    {reply, Reply, State};
 handle_call({status, Scenario}, _From, State) ->
     Res = case does_scenario_exist(Scenario) of
         true -> check_test(Scenario, State#state.scenario);
@@ -138,6 +147,9 @@ handle_cast(_Msg, State) ->
 -spec handle_info(any(), state()) -> {noreply, state()}.
 handle_info({start_scenario, Scenario, UserIds, ScenarioState}, State) ->
     start_scenario(Scenario, UserIds, ScenarioState),
+    {noreply, State};
+handle_info({check, Scenario, Interval}, State) ->
+    handle_check(Scenario, Interval),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -208,6 +220,21 @@ handle_do(Scenario, UserIds, State) ->
             {reply, {error, Error}, State}
     end.
 
+-spec handle_check(amoc:scenario(), non_neg_integer()) -> any().
+handle_check(Scenario, Interval) ->
+    case apply_safely(Scenario, continue, []) of
+        {ok, continue} ->
+            schedule_scenario_checking(Scenario, Interval),
+            continue;
+        {ok, {stop, Reason}} ->
+            lager:info("scenario should be terminated, reason=~p", [Reason]),
+            try_terminate_scenario(Scenario, Reason);
+        {error, Error, Reason} ->
+            lager:error("continue/1 callback failed, scenario should be"
+                       " terminated, error=~p, reason=~p", [Error, Reason]),
+            try_terminate_scenario(Scenario, {Error, Reason})
+    end.
+
 %% ------------------------------------------------------------------
 %% helpers
 %% ------------------------------------------------------------------
@@ -229,6 +256,49 @@ init_scenario(Scenario) ->
             Scenario:init();
         false ->
             skip
+    end.
+
+-spec maybe_start_scenario_checking(amoc:scenario()) -> ok | skip.
+maybe_start_scenario_checking(Scenario) ->
+    Callbacks = [{continue, 0}, {terminate, 1}],
+    case are_callbacks_exported(Scenario, Callbacks) of
+        true ->
+            schedule_scenario_checking(Scenario, checking_interval()),
+            lager:info("checking has been started", []),
+            ok;
+        false ->
+            lager:info("checking is not started as callbacks=~p are not"
+                       " exported", [Callbacks]),
+            skip
+    end.
+
+-spec are_callbacks_exported(amoc:scenario(), proplists:proplist()) -> boolean().
+are_callbacks_exported(Scenario, Callbacks) ->
+    case code:ensure_loaded(Scenario) of
+        {module, Scenario} ->
+            lists:all(fun({Func, Arity}) ->
+                              erlang:function_exported(Scenario, Func, Arity)
+                      end, Callbacks);
+        Error ->
+            lager:error("scenario module ~p cannot be found, reason: ~p",
+                        [Scenario, Error]),
+            false
+    end.
+
+-spec schedule_scenario_checking(amoc:scenario(), non_neg_integer()) ->
+    reference().
+schedule_scenario_checking(Scenario, Interval) ->
+    erlang:send_after(Interval, ?SERVER, {check, Scenario, Interval}).
+
+-spec try_terminate_scenario(amoc:scenario(), term()) -> term().
+try_terminate_scenario(Scenario, Reason) ->
+    case apply_safely(Scenario, terminate, [Reason]) of
+        {ok, _} ->
+            ok;
+        {error, E, R} ->
+            lager:error("terminate/1 callback failed, scenario cannot be"
+                       " terminated, error=~p, reason=~p", [E, R]),
+            application:stop(amoc)
     end.
 
 -spec start_users(amoc:scenario(), [amoc_scenario:user_id()], state()) ->
@@ -288,6 +358,10 @@ node_userids(Start, End, Nodes, NodeId) when is_integer(Nodes), Nodes > 0,
 interarrival() ->
     amoc_config:get(interarrival, ?INTERARRIVAL_DEFAULT).
 
+-spec checking_interval() -> integer().
+checking_interval() ->
+    amoc_config:get(scenario_checking_interval, ?CHECKING_INTERVAL_DEFAULT).
+
 -spec get_test_status() -> scenario_status().
 get_test_status() ->
     case supervisor:which_children(amoc_users_sup) of
@@ -308,4 +382,14 @@ check_test(Scenario, CurrentScenario) ->
     case Scenario =:= CurrentScenario of
         true -> get_test_status();
         false -> loaded
+    end.
+
+-spec apply_safely(atom(), atom(), [term()]) -> term().
+apply_safely(M, F, A) ->
+    try erlang:apply(M, F, A) of
+        Result ->
+            {ok, Result}
+    catch
+        Error:Reason ->
+            {error, Error, Reason}
     end.

--- a/src/amoc_dist.erl
+++ b/src/amoc_dist.erl
@@ -52,6 +52,7 @@ do(Scenario, Start, End, Opts) ->
     _Step = proplists:get_value(step, Opts, 1),
 
     amoc_event:notify({dist_do, Scenario, Start, End, Opts}),
+    amoc_controller:start_scenario_checking(Scenario),
     Count = length(Nodes),
     [ amoc_controller:do(Node, Scenario, Start, End, Count, Id, Opts) ||
       {Id, Node} <- lists:zip(lists:seq(1, Count), Nodes) ].

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -4,9 +4,13 @@
 %%==============================================================================
 -module(amoc_scenario).
 
+-optional_callbacks([continue/0, terminate/1]).
+
 -export_type([user_id/0]).
 
 -type user_id() :: non_neg_integer().
 
 -callback init() -> ok | {error, Reason :: term()}.
 -callback start(user_id()) -> any().
+-callback continue() -> continue | {stop, Reason :: term()}.
+-callback terminate(Reason :: term()) -> any().

--- a/test/amoc_controller_SUITE.erl
+++ b/test/amoc_controller_SUITE.erl
@@ -1,0 +1,118 @@
+-module(amoc_controller_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([scenario_is_terminated_when_stopped/1,
+         scenario_is_not_terminated_when_not_stopped/1,
+         checking_will_not_start_when_any_callback_is_not_exported/1,
+         checking_callback_exceptions_are_caught/1
+        ]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     scenario_is_terminated_when_stopped,
+     scenario_is_not_terminated_when_not_stopped,
+     checking_will_not_start_when_any_callback_is_not_exported,
+     checking_callback_exceptions_are_caught
+    ].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(amoc),
+    ok = application:set_env(amoc, scenario_checking_interval, 0),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+scenario_is_terminated_when_stopped(_Config) ->
+    %% GIVEN
+    S = self(),
+    StopReason = make_ref(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> {stop, StopReason} end),
+    meck:expect(test_scenario, terminate, fun(Reason) -> S ! Reason end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    receive
+        Reason ->
+            ?assertMatch(StopReason, Reason)
+    end.
+
+scenario_is_not_terminated_when_not_stopped(_Config) ->
+    %% GIVEN
+    S = self(),
+    Ref = make_ref(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> continue end),
+    meck:expect(test_scenario, terminate, fun(_) -> S ! Ref end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    receive
+        RecvRef ->
+            ?assertNotMatch(Ref, RecvRef)
+    after
+        50 ->
+            true
+    end.
+
+checking_will_not_start_when_any_callback_is_not_exported(Config) ->
+    %% GIVEN
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> {stop, test} end),
+
+    %% WHEN
+    Res = amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    ?assertMatch(Res, skip).
+
+checking_callback_exceptions_are_caught(_Config) ->
+    %% GIVEN
+    S = self(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> error(continue) end),
+    meck:expect(test_scenario, terminate, fun(Reason) ->
+                                                  S ! Reason,
+                                                  error(terminate)
+                                          end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    receive
+        Reason ->
+            ?assertMatch({error, continue}, Reason)
+    after
+        50 ->
+            error(recv_assert_match_timeout)
+    end,
+    Apps = application:which_applications(),
+    ?assertNot(proplists:is_defined(amoc, Apps)).

--- a/test/amoc_controller_SUITE_data/test_scenario.erl
+++ b/test/amoc_controller_SUITE_data/test_scenario.erl
@@ -1,0 +1,6 @@
+-module(test_scenario).
+-compile(export_all).
+
+continue() -> ok.
+
+terminate(_) -> ok.


### PR DESCRIPTION
It's now possible to terminate a scenario at any moment via two
new scenario callbacks `valid/0` and `terminate/1`. The former
checks if the current scenario is still valid e.g. some metrics are
below a certain treshold and must return `continue` or `{stop, Reason}`.
The latter one implements the actual termination. It's called only
if `valid/0` returned `{stop, Reason}`. The reason is passed to
the terminate callback. When `continue` is returned nothing happens.

The both callbacks are optional. Validation is scheduled only if
both of them are implemented. By default, validation interval
equals 60s. It can be changed by setting `scenario_validation_interval`
application environment.

Validation logic happens in `amoc_controller` process only on a
"master" Amoc node and only in "distributed mode" (scenario has
to be started via `amoc_dist:do/3/4`).

Closes MIM-269.