### PR TITLE
Make it possible to add users in batches

### DIFF
--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -8,6 +8,7 @@
 -define(SERVER, ?MODULE).
 -define(INTERARRIVAL_DEFAULT, 50).
 -define(CHECKING_INTERVAL_DEFAULT, 60*1000).
+-define(ADD_BATCH_INTERVAL_DEFAULT, 5*60*1000).
 -define(TABLE, amoc_users).
 
 -record(state, {scenario :: amoc:scenario() | undefined,
@@ -20,12 +21,18 @@
 -type node_id() :: non_neg_integer().
 -type handle_call_res() :: ok | {ok, term()} | {error, term()}.
 -type scenario_status() :: error | running | finished | loaded.
+-type user_count() :: non_neg_integer().
+-type interarrival() :: non_neg_integer().
+-type user_batch_strategy() :: [{node(), user_count(), interarrival()}].
 
 %% ------------------------------------------------------------------
 %% Types Exports
 %% ------------------------------------------------------------------
 
--export_type([scenario_status/0]).
+-export_type([scenario_status/0,
+              user_count/0,
+              interarrival/0,
+              user_batch_strategy/0]).
 
 %% ------------------------------------------------------------------
 %% API Function Exports
@@ -41,7 +48,8 @@
          remove/3,
          users/0,
          test_status/1,
-         start_scenario_checking/1]).
+         start_scenario_checking/1,
+         add_batches/2]).
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
 %% ------------------------------------------------------------------
@@ -71,27 +79,27 @@ do(Node, Scenario, Start, End, NodesCount, NodeId, Opts) ->
     Req = {do, Scenario, Start, End, NodesCount, NodeId, Opts},
     gen_server:call({?SERVER, Node}, Req).
 
--spec add(non_neg_integer()) -> ok.
+-spec add(user_count()) -> ok.
 add(Count) ->
     gen_server:cast(?SERVER, {add, Count}).
 
--spec add(node(), non_neg_integer()) -> ok.
+-spec add(node(), user_count()) -> ok.
 add(Node, Count) ->
     gen_server:cast({?SERVER, Node}, {add, Count}).
 
--spec add(node(), non_neg_integer(), proplists:proplist()) -> ok.
+-spec add(node(), user_count(), proplists:proplist()) -> ok.
 add(Node, Count, Opts) ->
     gen_server:cast({?SERVER, Node}, {add, Count, Opts}).
 
--spec remove(non_neg_integer()) -> ok.
+-spec remove(user_count()) -> ok.
 remove(Count) ->
     remove(Count, []).
 
--spec remove(non_neg_integer(), amoc:remove_opts()) ->ok.
+-spec remove(user_count(), amoc:remove_opts()) ->ok.
 remove(Count, Opts) ->
     gen_server:cast(?SERVER, {remove, Count, Opts}).
 
--spec remove(node(), non_neg_integer(), amoc:remove_opts()) ->ok.
+-spec remove(node(), user_count(), amoc:remove_opts()) ->ok.
 remove(Node, Count, Opts) ->
     gen_server:cast({?SERVER, Node}, {remove, Count, Opts}).
 
@@ -107,6 +115,11 @@ test_status(ScenarioName) ->
 -spec start_scenario_checking(amoc:scenario()) -> ok | skip | {error, term()}.
 start_scenario_checking(Scenario) ->
     gen_server:call(?SERVER, {start_scenario_checking, Scenario}).
+
+-spec add_batches(non_neg_integer(), amoc:scenario()) -> ok | skip |
+                                                         {error, term()}.
+add_batches(BatchCount, Scenario) ->
+    gen_server:call(?SERVER, {add_batches, BatchCount, Scenario}).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
@@ -129,6 +142,9 @@ handle_call(users, _From, State) ->
     {reply, {ok, Reply}, State};
 handle_call({start_scenario_checking, Scenario}, _From, State) ->
     Reply = maybe_start_scenario_checking(Scenario),
+    {reply, Reply, State};
+handle_call({add_batches, BatchCount, Scenario}, _From, State) ->
+    Reply = maybe_add_batches(Scenario, BatchCount, 1, 0),
     {reply, Reply, State};
 handle_call({status, Scenario}, _From, State) ->
     Res = case does_scenario_exist(Scenario) of
@@ -159,6 +175,11 @@ handle_info({start_scenario, Scenario, UserIds, ScenarioState}, State) ->
 handle_info({check, Scenario, Interval}, State) ->
     handle_check(Scenario, Interval),
     {noreply, State};
+handle_info({add_batch, {Scenario, BatchCount, CurrentBatch, PrevUserCount},
+             Interval}, State) ->
+    handle_add_batch(Scenario, BatchCount, CurrentBatch, PrevUserCount,
+                     Interval),
+    {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -172,7 +193,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% ------------------------------------------------------------------
 %% callbacks handlers
 %% ------------------------------------------------------------------
--spec handle_add(non_neg_integer(), state(), proplists:proplist()) ->
+-spec handle_add(user_count(), state(), proplists:proplist()) ->
     ok | list({ok, pid()}).
 handle_add(_Count, #state{scenario=undefined}, _Opts) ->
     lager:error("add users invoked, but no scenario defined");
@@ -189,7 +210,7 @@ handle_add(Count, #state{scenario=Scenario,
     Interarrival = proplists:get_value(interarrival, Opts, interarrival()),
     start_users(Scenario, UserIds, Interarrival, State).
 
--spec handle_remove(non_neg_integer(), amoc:remove_opts(), state()) -> ok.
+-spec handle_remove(user_count(), amoc:remove_opts(), state()) -> ok.
 handle_remove(_Count, _Opts, #state{scenario=undefined}) ->
     lager:error("remove users invoked, but no scenario defined");
 handle_remove(Count, Opts, _State) when
@@ -245,6 +266,23 @@ handle_check(Scenario, Interval) ->
             try_terminate_scenario(Scenario, {Error, Reason})
     end.
 
+-spec handle_add_batch(amoc:scenario(), non_neg_integer(), non_neg_integer(),
+                       non_neg_integer(), non_neg_integer()) ->
+   any().
+handle_add_batch(Scenario, BatchCount, CurrentBatch, PrevUserCount, Interval) ->
+    case apply_safely(Scenario, next_user_batch,
+                      [CurrentBatch, PrevUserCount]) of
+        {ok, BatchStrategy} ->
+            add_batch(BatchStrategy),
+            TotalUserCount = total_users_in_batch(BatchStrategy),
+            maybe_schedule_add_batch({Scenario, BatchCount - 1, CurrentBatch + 1,
+                                      TotalUserCount}, Interval);
+        {error, Error, Reason} ->
+            lager:error("next_user_batch/2 callback failed, scenario should be"
+                        " terminated, error=~p, reason=~p", [Error, Reason]),
+            try_terminate_scenario(Scenario, {Error, Reason})
+    end.
+
 %% ------------------------------------------------------------------
 %% helpers
 %% ------------------------------------------------------------------
@@ -282,6 +320,26 @@ maybe_start_scenario_checking(Scenario) ->
             skip
     end.
 
+-spec maybe_add_batches(amoc:scenario(), non_neg_integer(), non_neg_integer(),
+                        non_neg_integer()) -> ok | skip.
+maybe_add_batches(Scenario, BatchCount, CurrentBatch, PrevUserCount) ->
+    Callbacks = [{next_user_batch, 2}],
+    case are_callbacks_exported(Scenario, Callbacks) of
+        true ->
+            maybe_schedule_add_batch({Scenario, BatchCount, CurrentBatch,
+                                      PrevUserCount}, add_batch_interval()),
+            ok;
+        false ->
+            lager:info("add batches is not possible as callbacks=~p are not"
+                       " exported", [Callbacks]),
+            skip
+    end.
+
+-spec add_batch(user_batch_strategy()) -> any().
+add_batch(BatchStrategy) ->
+    [amoc_controller:add(Node, UserCount, [{interarrival, Interarrival}])
+     || {Node, UserCount, Interarrival} <- BatchStrategy].
+
 -spec are_callbacks_exported(amoc:scenario(), proplists:proplist()) -> boolean().
 are_callbacks_exported(Scenario, Callbacks) ->
     case code:ensure_loaded(Scenario) of
@@ -298,7 +356,17 @@ are_callbacks_exported(Scenario, Callbacks) ->
 -spec schedule_scenario_checking(amoc:scenario(), non_neg_integer()) ->
     reference().
 schedule_scenario_checking(Scenario, Interval) ->
-    erlang:send_after(Interval, ?SERVER, {check, Scenario, Interval}).
+    schedule_periodic_action(Scenario, Interval, check).
+
+-spec maybe_schedule_add_batch(term(), non_neg_integer()) -> reference().
+maybe_schedule_add_batch({_, BatchCount, _, _}, _) when BatchCount == 0 ->
+    ok;
+maybe_schedule_add_batch(Data, Interval) ->
+    schedule_periodic_action(Data, Interval, add_batch).
+
+-spec schedule_periodic_action(term(), non_neg_integer(), atom()) -> reference().
+schedule_periodic_action(Data, Interval, Action) ->
+    erlang:send_after(Interval, ?SERVER, {Action, Data, Interval}).
 
 -spec try_terminate_scenario(amoc:scenario(), term()) -> term().
 try_terminate_scenario(Scenario, Reason) ->
@@ -311,12 +379,12 @@ try_terminate_scenario(Scenario, Reason) ->
             application:stop(amoc)
     end.
 
--spec start_users(amoc:scenario(), [amoc_scenario:user_id()], non_neg_integer(),
+-spec start_users(amoc:scenario(), [amoc_scenario:user_id()], interarrival(),
                   state()) -> [term()].
 start_users(Scenario, UserIds, Interarrival, State) ->
     [ start_user(Scenario, Id, Interarrival, State) || Id <- UserIds ].
 
--spec start_user(amoc:scenario(), amoc_scenario:user_id(), non_neg_integer(),
+-spec start_user(amoc:scenario(), amoc_scenario:user_id(), interarrival(),
                  state()) -> supervisor:startchild_ret().
 start_user(Scenario, Id, Interarrival, State) ->
     R = supervisor:start_child(amoc_users_sup, [Scenario, Id, State]),
@@ -332,11 +400,11 @@ stop_users(Users, _ForceRemove=true) ->
 stop_users(Users, _ForceRemove=false) ->
     [ Pid ! stop || {_, Pid} <- Users ].
 
--spec last_users(non_neg_integer()) -> [{amoc_scenario:user_id(), pid()}].
+-spec last_users(user_count()) -> [{amoc_scenario:user_id(), pid()}].
 last_users(Count) ->
     [ User || User <- last_users(Count, ets:last(?TABLE), []) ].
 
--spec last_users(non_neg_integer(), amoc_scenario:user_id() | '$end_of_table',
+-spec last_users(user_count(), amoc_scenario:user_id() | '$end_of_table',
                  [{amoc_scenario:user_id(), pid()}]) ->
     [{amoc_scenario:user_id(), pid()}].
 last_users(0, _, Acc) ->
@@ -364,13 +432,23 @@ node_userids(Start, End, Nodes, NodeId) when is_integer(Nodes), Nodes > 0,
         end,
     lists:filter(F, lists:seq(Start, End)).
 
--spec interarrival() -> integer().
+-spec total_users_in_batch(user_batch_strategy()) ->
+    non_neg_integer().
+total_users_in_batch(BatchStrategy) ->
+    lists:foldl(fun({_, UserCount, _}, Acc) -> Acc + UserCount end, 0,
+                BatchStrategy).
+
+-spec interarrival() -> interarrival().
 interarrival() ->
     amoc_config:get(interarrival, ?INTERARRIVAL_DEFAULT).
 
 -spec checking_interval() -> integer().
 checking_interval() ->
     amoc_config:get(scenario_checking_interval, ?CHECKING_INTERVAL_DEFAULT).
+
+-spec add_batch_interval() -> integer().
+add_batch_interval() ->
+    amoc_config:get(add_batch_interval, ?ADD_BATCH_INTERVAL_DEFAULT).
 
 -spec get_test_status() -> scenario_status().
 get_test_status() ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -115,7 +115,7 @@ start_scenario_checking(Scenario) ->
 init([]) ->
     process_flag(priority, max),
     State = #state{scenario = undefined,
-                   nodes = 0},
+                   nodes = undefined},
     {ok, State}.
 
 -spec handle_call(any(), any(), state()) -> {reply, handle_call_res(), state()}.

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -4,7 +4,7 @@
 %%==============================================================================
 -module(amoc_scenario).
 
--optional_callbacks([continue/0, terminate/1]).
+-optional_callbacks([continue/0, terminate/1, next_user_batch/2]).
 
 -export_type([user_id/0]).
 
@@ -14,3 +14,6 @@
 -callback start(user_id()) -> any().
 -callback continue() -> continue | {stop, Reason :: term()}.
 -callback terminate(Reason :: term()) -> any().
+-callback next_user_batch(BatchIndex :: non_neg_integer(),
+                          PrevUserCount :: non_neg_integer()) ->
+    amoc_controller:user_batch_strategy().

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -19,7 +19,8 @@
          get_scenario_status_returns_loaded_when_scenario_is_not_running/1,
          patch_scenario_returns_404_when_scenario_not_exists/1,
          patch_scenario_returns_400_when_malformed_request/1,
-         patch_scenario_returns_200_when_request_ok_and_module_exists/1
+         patch_scenario_returns_200_when_request_ok_and_module_exists/1,
+         patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists/1
         ]).
 
 
@@ -32,15 +33,22 @@ all() ->
      get_scenario_status_returns_loaded_when_scenario_is_not_running,
      patch_scenario_returns_404_when_scenario_not_exists,
      patch_scenario_returns_400_when_malformed_request,
-     patch_scenario_returns_200_when_request_ok_and_module_exists
+     patch_scenario_returns_200_when_request_ok_and_module_exists,
+     patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists
     ].
 
 init_per_testcase(
   patch_scenario_returns_200_when_request_ok_and_module_exists,
   Config) ->
-    ok = meck:new(amoc_dist, [unstick]),
-    Fun = fun(_,1,_) -> [ok] end,
-    ok = meck:expect(amoc_dist, do, Fun),
+    mock_amoc_dist_do(),
+    create_env(Config),
+    Config;
+
+init_per_testcase(
+  patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists,
+  Config) ->
+    mock_amoc_dist_do(),
+    mock_amoc_controller_add_batches(),
     create_env(Config),
     Config;
 
@@ -52,6 +60,13 @@ end_per_testcase(
   patch_scenario_returns_200_when_request_ok_and_module_exists,
   _Config) ->
     ok = meck:unload(amoc_dist),
+    destroy_env();
+
+end_per_testcase(
+  patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists,
+  _Config) ->
+    ok = meck:unload(amoc_dist),
+    ok = meck:unload(amoc_controller),
     destroy_env();
 
 end_per_testcase(_, _Config) ->
@@ -140,6 +155,17 @@ patch_scenario_returns_200_when_request_ok_and_module_exists(_Config) ->
     meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
     ?assertEqual(200, CodeHttp).
 
+patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists(_Config) ->
+    %% given
+    RequestBody = jiffy:encode({[{users, 10}, {batches, 10}]}),
+    %% when
+    {CodeHttp, _Body} = amoc_api_helper:patch(
+                          ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
+    %% then
+    %% Maybe check Body, as answer format will be ready
+    meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
+    meck:wait(amoc_controller, add_batches, ['sample_test1', 10], 2000),
+    ?assertEqual(200, CodeHttp).
 
 %% Helpers
 
@@ -171,6 +197,18 @@ data(Config, Path) ->
 given_amoc_dist_mocked_with_test_status(Value) ->
     meck:new(amoc_dist, [passtrough]),
     meck:expect(amoc_dist, test_status, fun(_) -> Value end).
+
+-spec mock_amoc_dist_do() -> ok.
+mock_amoc_dist_do() ->
+    ok = meck:new(amoc_dist, [unstick]),
+    Fun = fun(_,1,_) -> [ok] end,
+    ok = meck:expect(amoc_dist, do, Fun).
+
+-spec mock_amoc_controller_add_batches() -> ok.
+mock_amoc_controller_add_batches() ->
+    ok = meck:new(amoc_controller, [unstick]),
+    Fun = fun(_,_) -> ok end,
+    ok = meck:expect(amoc_controller, add_batches, Fun).
 
 -spec cleanup_amoc_dist() -> ok.
 cleanup_amoc_dist() ->

--- a/test/amoc_controller_SUITE.erl
+++ b/test/amoc_controller_SUITE.erl
@@ -9,7 +9,12 @@
          scenario_is_terminated_when_stopped/1,
          scenario_is_not_terminated_when_not_stopped/1,
          checking_will_not_start_when_any_callback_is_not_exported/1,
-         checking_callback_exceptions_are_caught/1
+         checking_callback_exceptions_are_caught/1,
+         user_batches_are_added_according_to_strategy/1,
+         user_batches_number_can_be_limited/1,
+         user_batch_callback_receives_valid_parameters/1,
+         user_batches_respect_user_interarrival/1,
+         user_batches_will_not_be_added_when_callback_is_not_exported/1
         ]).
 
 %%--------------------------------------------------------------------
@@ -32,7 +37,8 @@
 
 all() ->
     [
-     {group, scenario_checking}
+     {group, scenario_checking},
+     {group, user_batches}
     ].
 
 groups() ->
@@ -43,6 +49,14 @@ groups() ->
        scenario_is_not_terminated_when_not_stopped,
        checking_will_not_start_when_any_callback_is_not_exported,
        checking_callback_exceptions_are_caught
+      ]},
+     {user_batches, [shuffle],
+      [
+       user_batches_are_added_according_to_strategy,
+       user_batches_number_can_be_limited,
+       user_batch_callback_receives_valid_parameters,
+       user_batches_respect_user_interarrival,
+       user_batches_will_not_be_added_when_callback_is_not_exported
       ]}
     ].
 
@@ -62,23 +76,55 @@ end_per_suite(Config) ->
 
 init_per_group(scenario_checking, Config) ->
     ok = application:set_env(amoc, scenario_checking_interval, 0),
+    Config;
+init_per_group(user_batches, Config) ->
+    ok = application:set_env(amoc, add_batch_interval, 0),
+    ok = application:set_env(amoc, interarrival, 0),
+    %% Mock supervisor:start_child/2 in order to change the behavior of
+    %% amoc_controller:start_user/4. Now a user is no longer a process but only
+    %% an entry in an ETS table. It simplifies testing substantially.
+    meck:new(supervisor, [unstick, passthrough, no_link]),
+    meck:expect(supervisor, start_child,
+                fun(amoc_users_sup, [_, Id, _]) ->
+                        ets:insert(amoc_users, {Id, self()});
+                   (Pid, Args) ->
+                        meck:passthrough([Pid, Args])
+                end),
     Config.
 
+end_per_group(user_batches, Config) ->
+    meck:unload(supervisor),
+    Config;
 end_per_group(_Group, Config) ->
     Config.
 
 init_per_testcase(checking_callback_exceptions_are_caught, Config) ->
     meck:new(application, [unstick, passthrough, no_link]),
     Config;
+init_per_testcase(Case, Config) when
+      Case == user_batches_are_added_according_to_strategy orelse
+      Case == user_batches_number_can_be_limited orelse
+      Case == user_batch_callback_receives_valid_parameters orelse
+      Case == user_batches_respect_user_interarrival ->
+    setup_amoc_controller(),
+    Config;
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(checking_will_not_start_when_any_callback_is_not_exported,
-                 Config) ->
+end_per_testcase(Case, Config) when
+      Case == checking_will_not_start_when_any_callback_is_not_exported orelse
+      Case == user_batches_will_not_be_added_when_callback_is_not_exported ->
     meck:unload(test_scenario_no_exports),
     Config;
 end_per_testcase(checking_callback_exceptions_are_caught, Config) ->
     meck:unload(application),
+    Config;
+end_per_testcase(Case, Config) when
+      Case == user_batches_are_added_according_to_strategy orelse
+      Case == user_batches_number_can_be_limited orelse
+      Case == user_batch_callback_receives_valid_parameters orelse
+      Case == user_batches_respect_user_interarrival ->
+    reset_amoc_controller(),
     Config;
 end_per_testcase(_Case, Config) ->
     Config.
@@ -153,3 +199,103 @@ checking_callback_exceptions_are_caught(_Config) ->
     %% THEN
     timer:sleep(100),
     [?recvAssertMatch(P) || P <- [{error, continue}, amoc_stopped]].
+
+%%--------------------------------------------------------------------
+%% GROUP user_batches
+%%--------------------------------------------------------------------
+
+user_batches_are_added_according_to_strategy(_Config) ->
+    %% GIVEN
+    Node1Users = 10,
+    Node2Users = 20,
+    TotalUsers = Node1Users + Node2Users,
+    BatchStrategy = [{node(), Node1Users, 0},
+                     {node(), Node2Users, 0}],
+    BatchCount = 1,
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertMatch(TotalUsers,
+                 proplists:get_value(count, amoc_controller:users())).
+
+user_batches_number_can_be_limited(_Config) ->
+    %% GIVEN
+    UserCount = 1,
+    BatchStrategy = [{node(), UserCount, 0}],
+    BatchCount = 10,
+    TotalUsers = UserCount * BatchCount,
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertMatch(TotalUsers,
+                 proplists:get_value(count, amoc_controller:users())).
+
+user_batch_callback_receives_valid_parameters(_Config) ->
+    %% GIVEN
+    S = self(),
+    BatchIndexWithUserCount =
+        [{X, rand:uniform(10)} || X <- lists:seq(2,10)], %% {BatchIndex, UserCount}
+    BatchCount = length(BatchIndexWithUserCount) + 1,
+    meck:expect(test_scenario, next_user_batch,
+                fun(BatchIndex, PrevUserCount) ->
+                        S ! {BatchIndex, PrevUserCount},
+                        {_, UserCount} =
+                            lists:nth(BatchIndex,
+                                      BatchIndexWithUserCount ++ [{0,0}]),
+                        [{node(), UserCount, 0}]
+                end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    [?recvAssertMatch({BatchIndex, PrevUserCount})
+     || {BatchIndex, PrevUserCount} <- [{1,0}] ++ BatchIndexWithUserCount].
+
+user_batches_respect_user_interarrival(_Config) ->
+    %% GIVEN
+    UserCount = 2,
+    BatchCount = 1,
+    Interarrival = 1000,
+    BatchStrategy = [{node(), UserCount, Interarrival}],
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertNotMatch(UserCount, ets:info(amoc_users, size)).
+
+user_batches_will_not_be_added_when_callback_is_not_exported(_Config) ->
+    %% GIVEN
+    meck:new(test_scenario_no_exports, [non_strict]),
+
+    %% WHEN
+    Res = amoc_controller:add_batches(1, test_scenario_no_exports),
+
+    %% THEN
+    ?assertMatch(Res, skip).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+remove_all_users() ->
+    ets:delete_all_objects(amoc_users).
+
+setup_amoc_controller() ->
+    amoc_controller:do(test_scenario, 1, 2),
+    timer:sleep(100),
+    remove_all_users().
+
+reset_amoc_controller() ->
+    exit(whereis(amoc_controller), kill).

--- a/test/amoc_controller_SUITE_data/test_scenario.erl
+++ b/test/amoc_controller_SUITE_data/test_scenario.erl
@@ -1,6 +1,0 @@
--module(test_scenario).
--compile(export_all).
-
-continue() -> ok.
-
-terminate(_) -> ok.


### PR DESCRIPTION
There is new `amoc_controller:add_batches/2` function that allows to add
users in batches according to some strategy. The function takes the
scenario module and the number of batches as parameters.

The strategy of adding users should be returned by `next_user_batch/2`
callback implemented in the scenario module. The callback is optional.
The batch index and the number of users added in the previous batch are
parmeters that are passed to the callback function.  The strategy is a
list of `{Node, NumOfUsers, Interarrival}`.

Batches are added every batch interval specified by `add_batch_interval`
application environment variable, which is 5 minutes by default.

Adding batches can be sheduled via HTTP API by specifying `batches` key
in a body request to `scenarios/$SCENARIO` endpoint.

Closes MIM-270.