### PR TITLE
Allow to pass extra code paths to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ After that the scenario will keep running.
 ## Configuration
 
 amoc is configured through OTP application environment variables that
-are loaded from the configuration file, operating system environment variables 
+are loaded from the configuration file, operating system environment variables
 (with prefix ``AMOC_``) and Erlang application environment variables
 (`priv/app.config`).
 
@@ -247,6 +247,12 @@ docker run -d \
            --name amoc_container \
            amoc_image:tag
 ```
+
+If there is a need to point amoc inside the container to some additional paths with code,
+it can be done by specifying variable `AMOC_EXTRA_CODE_PATHS` like in the examples below.
+
+* `-e AMOC_EXTRA_CODE_PATHS=/a_single_path`
+* `-e AMOC_EXTRA_CODE_PATHS="/first_path /second_path"`
 
 ### Useful commands with Amoc container:
 

--- a/docker/config/vm.args
+++ b/docker/config/vm.args
@@ -4,14 +4,6 @@
 ## Cookie for distributed erlang
 -setcookie amoc
 
-## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
-## (Disabled by default..use with caution!)
-##-heart
-
-## Enable kernel poll and a few async threads
-+K true
-##+A 5
-
 ## Increase number of concurrent ports/sockets
 -env ERL_MAX_PORTS 500000
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,12 +4,19 @@ set -x
 
 AMOC_GRAPHITE_HOST=${AMOC_GRAPHITE_HOST:-127.0.0.1}
 AMOC_GRAPHITE_PORT=${AMOC_GRAPHITE_PORT:-2003}
+AMOC_EXTRA_CODE_PATHS=${AMOC_EXTRA_CODE_PATHS:-""}
 
 SYSCONFIG="/home/amoc/amoc/releases/0.9.0/sys.config"
+VMARGS="/home/amoc/amoc/releases/0.9.0/vm.args"
 sed -e "s/AMOC_GRAPHITE_HOST/${AMOC_GRAPHITE_HOST}/" /sys.config.template > \
     ${SYSCONFIG}
 sed -i -e "s/AMOC_GRAPHITE_PORT/${AMOC_GRAPHITE_PORT}/" ${SYSCONFIG}
 sed -i -e "s/AMOC_PREFIX/${AMOC_PREFIX}/" ${SYSCONFIG}
 sed -i -e "s/AMOC_HOSTS/${AMOC_HOSTS}/" ${SYSCONFIG}
+
+if [[ -n "${AMOC_EXTRA_CODE_PATHS// /}" ]]; then
+    #if the var is not empty and contains sth else then just spaces
+    echo "-pz ${aMOC_EXTRA_CODE_PATHS}" >> ${VMARGS}
+fi
 
 /sbin/my_init

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -16,7 +16,7 @@ sed -i -e "s/AMOC_HOSTS/${AMOC_HOSTS}/" ${SYSCONFIG}
 
 if [[ -n "${AMOC_EXTRA_CODE_PATHS// /}" ]]; then
     #if the var is not empty and contains sth else then just spaces
-    echo "-pz ${aMOC_EXTRA_CODE_PATHS}" >> ${VMARGS}
+    echo "-pz ${AMOC_EXTRA_CODE_PATHS}" >> ${VMARGS}
 fi
 
 /sbin/my_init


### PR DESCRIPTION
The paths with extra code can be passed via `AMOC_EXTRA_CODE_PATHS` env variable.