### PR TITLE
Run xref on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install: make compile
 script:
     - make test
     - rebar3 dialyzer
+    - rebar3 xref
 
 cache:
     directories:

--- a/rebar.config
+++ b/rebar.config
@@ -35,3 +35,6 @@
             {copy, "scenarios", "scenarios"}
         ]}
     ]}.
+
+    {xref_checks,[undefined_function_calls, undefined_functions, locals_not_used,
+                  deprecated_function_calls, deprecated_functions]}.

--- a/src/amoc_annotations.erl
+++ b/src/amoc_annotations.erl
@@ -71,7 +71,7 @@ annotate(Tags, Format, Args) ->
             Json = jiffy:encode(#{what => What, tags => Tags}),
             Path = "/events/",
             Destination = "http://" ++ Host,
-            {ok, Client} = fusco:start_link({Destination, []}),
+            {ok, Client} = fusco:start_link(Destination, []),
             ok = fusco:connect(Client),
             Response = fusco:request(Client, Path, "POST", [], Json, 5000),
             {ok, {{200, _}, _, _}} = Response,


### PR DESCRIPTION
This PR adds xref check to CI and fixes a call to undefined function from `amoc_annotations`.