### PR TITLE
AWS load tests inspired improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ below a certain treshold and must return `continue` or `{stop, Reason}`.
 The latter one implements the actual termination. It's called only
 if `continue/0` returned `{stop, Reason}`. The reason is passed to
 the terminate callback. When continue is returned nothing happens.
-The both callbacks are optional. Checking scenario state is scheduled
-only if both of them are implemented. By default, checking interval
+Both callbacks are optional. Checking scenario state is scheduled
+only if both of them are implemented. By default, the checking interval
 equals 60s. It can be changed by setting `scenario_checking_interval`
-application environment.
-Checking logic happens in `amoc_controller` process only on a
-"master" Amoc node and only in "distributed mode" (scenario has
+application environment variable.
+The checking logic happens in `amoc_controller` process only on a
+"master" Amoc node and only in the "distributed mode" (scenario has
 to be started via `amoc_dist:do/3/4`).
 
 #### 2. Add users in batches
 
-There is `amoc_controller:add_batches/2` function that allows to add
+There is an `amoc_controller:add_batches/2` function that allows to add
 users in batches according to some strategy. The function takes the
 scenario module and the number of batches as parameters.
 The strategy of adding users should be returned by `next_user_batch/2`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,41 @@ If additional dependencies are required by your scenario, a `rebar.config` file
 can be created inside the `scenario` dir and `deps` from that file will be
 merged with amoc's `deps`.
 
+### Advanced scenario features
+
+#### 1. Terminate a scenario at any time
+
+It's possible to terminate a scenario at any moment via two
+optional scenario callbacks `continue/0` and `terminate/1`. The former
+checks if the current scenario is still valid e.g. some metrics are
+below a certain treshold and must return `continue` or `{stop, Reason}`.
+The latter one implements the actual termination. It's called only
+if `continue/0` returned `{stop, Reason}`. The reason is passed to
+the terminate callback. When continue is returned nothing happens.
+The both callbacks are optional. Checking scenario state is scheduled
+only if both of them are implemented. By default, checking interval
+equals 60s. It can be changed by setting `scenario_checking_interval`
+application environment.
+Checking logic happens in `amoc_controller` process only on a
+"master" Amoc node and only in "distributed mode" (scenario has
+to be started via `amoc_dist:do/3/4`).
+
+#### 2. Add users in batches
+
+There is `amoc_controller:add_batches/2` function that allows to add
+users in batches according to some strategy. The function takes the
+scenario module and the number of batches as parameters.
+The strategy of adding users should be returned by `next_user_batch/2`
+callback implemented in the scenario module. The callback is optional.
+The batch index and the number of users added in the previous batch are
+parmeters that are passed to the callback function. The strategy is a
+list of `{Node, NumOfUsers, Interarrival}`.
+Batches are added every batch interval specified by `add_batch_interval`
+application environment variable, which is 5 minutes by default.
+Adding batches can be sheduled via HTTP API by specifying batches key
+in a body request to `scenarios/$SCENARIO` endpoint.
+See [REST API docs](./REST_API_DOCS.md#start-scenario).
+
 ## Running a scenario
 
 ### Locally

--- a/REST_API_DOCS.md
+++ b/REST_API_DOCS.md
@@ -26,69 +26,74 @@ Requests and responses format
 #### Request
 `GET /scenarios`
 #### Response
-`
+```json
 {
     "scenarios": [ScenarioName]
 }
-`
+```
 ### Add new scenario
 
 #### Request
 `POST /scenarios` with:
-`
+```json
 {
     "scenario": ScenarioName, //string
     "module_source": ModuleSourceCode //string
 }
-`
+```
 #### Response
-`
+```json
 {
     "compile" : "ok" | "error"
 }
-`
+```
 ### Start scenario
 
 #### Request 
 `PATCH /scenarios/:id` (:id is a module name of scenario) with:
-`
+```json
 {
-    "users": NumberOfUsers //integer
+    "users": NumberOfUsers, //integer
+    "batches": NumOfBatches //integer
 }
-`
+```
+> `"batches"` key is optional, see [Add users in batches](./README.md#2-add-users-in-batches)
 #### Response
-`
+```json
 {
     "scenario": "started" | "wrong_json"
 }
-`
+```
 ### Scenario status
 
 #### Request
 `GET /scenarios/:id` (:id is a module name of scenario)
 #### Response
-`{
+```json
+{
     "scenario_status": "loaded" | "running" | "finished"
-}`
+}```
 Attention: when scenario with `:id` does not exists API returns 404.
 ### Ping nodes
 
 #### Request
 `GET /nodes`
 #### Response
-`{
+```json
+{
     "nodes": 
     {
         NodeName1: "up" | "down",
         NodeName2: "up" | "down",
         ...
     }
-}`
+}```
 ### Node status
 
 #### Request
 `GET /status`
 #### Response
-`{
+```json
+{
     "node_status": "up" | "down"
-}`
+}```

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -6,6 +6,7 @@
   {applications, [
                   kernel,
                   stdlib,
+                  sasl,
                   lager,
                   jiffy,
                   exometer,

--- a/src/amoc.app.src
+++ b/src/amoc.app.src
@@ -15,7 +15,8 @@
                   trails,
                   cowboy,
                   cowboy_swagger,
-                  amqp_client
+                  amqp_client,
+                  runtime_tools
                  ]},
   {mod, { amoc_app, []}},
   {env, [{repeat_interval, 60000},

--- a/src/amoc_api_scenario_handler.erl
+++ b/src/amoc_api_scenario_handler.erl
@@ -187,6 +187,6 @@ get_result(Result) ->
 -spec maybe_add_batches(amoc:scenario(), non_neg_integer()) -> ok | skip |
                                                                {error, term()}.
 maybe_add_batches(Scenario, Batches) when is_integer(Batches) ->
-    amoc_controller:add_batches(Scenario, Batches);
+    amoc_controller:add_batches(Batches, Scenario);
 maybe_add_batches(_, _) ->
     skip.

--- a/src/amoc_api_scenario_handler.erl
+++ b/src/amoc_api_scenario_handler.erl
@@ -158,7 +158,7 @@ from_json(Req, State = #state{resource = Resource}) ->
 
 
 %% internal function
--spec get_users_and_batches_from_body(cowboy_req:req()) -> {ok, term(),
+-spec get_users_and_batches_from_body(cowboy_req:req()) -> {ok, term(), term(),
                                                             cowboy_req:req()} |
         {error, bad_request, cowboy_req:req()}.
 get_users_and_batches_from_body(Req) ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -13,7 +13,7 @@
 
 -record(state, {scenario :: amoc:scenario() | undefined,
                 scenario_state :: any(),
-                nodes ::  non_neg_integer(),
+                nodes ::  non_neg_integer() | undefined,
                 node_id :: node_id() | undefined}).
 
 

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -115,7 +115,7 @@ start_scenario_checking(Scenario) ->
 init([]) ->
     process_flag(priority, max),
     State = #state{scenario = undefined,
-                   nodes = 0},
+                   nodes = undefined},
     {ok, State}.
 
 -spec handle_call(any(), any(), state()) -> {reply, handle_call_res(), state()}.

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -35,6 +35,7 @@
          do/7,
          add/1,
          add/2,
+         add/3,
          remove/1,
          remove/2,
          remove/3,
@@ -77,6 +78,10 @@ add(Count) ->
 -spec add(node(), non_neg_integer()) -> ok.
 add(Node, Count) ->
     gen_server:cast({?SERVER, Node}, {add, Count}).
+
+-spec add(node(), non_neg_integer(), proplists:proplist()) -> ok.
+add(Node, Count, Opts) ->
+    gen_server:cast({?SERVER, Node}, {add, Count, Opts}).
 
 -spec remove(non_neg_integer()) -> ok.
 remove(Count) ->
@@ -136,7 +141,10 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast({add, Count}, State) ->
-    handle_add(Count, State),
+    handle_add(Count, State, []),
+    {noreply, State};
+handle_cast({add, Count, Opts}, State) ->
+    handle_add(Count, State, Opts),
     {noreply, State};
 handle_cast({remove, Count, Opts}, State) ->
     handle_remove(Count, Opts, State),
@@ -164,20 +172,22 @@ code_change(_OldVsn, State, _Extra) ->
 %% ------------------------------------------------------------------
 %% callbacks handlers
 %% ------------------------------------------------------------------
--spec handle_add(non_neg_integer(), state()) -> ok | list({ok, pid()}).
-handle_add(_Count, #state{scenario=undefined}) ->
+-spec handle_add(non_neg_integer(), state(), proplists:proplist()) ->
+    ok | list({ok, pid()}).
+handle_add(_Count, #state{scenario=undefined}, _Opts) ->
     lager:error("add users invoked, but no scenario defined");
 handle_add(Count, #state{scenario=Scenario,
                          scenario_state=State,
                          nodes = Nodes,
-                         node_id = NodeId}) when
+                         node_id = NodeId}, Opts) when
       is_integer(Count), Count > 0 ->
     Last = case ets:last(?TABLE) of
                '$end_of_table' -> 0;
                Other -> Other
            end,
     UserIds = node_userids(Last+1, Last+Count, Nodes, NodeId),
-    start_users(Scenario, UserIds, State).
+    Interarrival = proplists:get_value(interarrival, Opts, interarrival()),
+    start_users(Scenario, UserIds, Interarrival, State).
 
 -spec handle_remove(non_neg_integer(), amoc:remove_opts(), state()) -> ok.
 handle_remove(_Count, _Opts, #state{scenario=undefined}) ->
@@ -253,7 +263,7 @@ start_scenario(Scenario, UserIds, State) ->
     Length = erlang:length(UserIds),
     lager:info("starting scenario begin_id=~p, end_id=~p, length=~p",
                [Start, End, Length]),
-    start_users(Scenario, UserIds, State).
+    start_users(Scenario, UserIds, interarrival(), State).
 
 -spec init_scenario(amoc:scenario()) -> any().
 init_scenario(Scenario) ->
@@ -310,16 +320,16 @@ try_terminate_scenario(Scenario, Reason) ->
             application:stop(amoc)
     end.
 
--spec start_users(amoc:scenario(), [amoc_scenario:user_id()], state()) ->
-    [term()].
-start_users(Scenario, UserIds, State) ->
-    [ start_user(Scenario, Id, State) || Id <- UserIds ].
+-spec start_users(amoc:scenario(), [amoc_scenario:user_id()], non_neg_integer(),
+                  state()) -> [term()].
+start_users(Scenario, UserIds, Interarrival, State) ->
+    [ start_user(Scenario, Id, Interarrival, State) || Id <- UserIds ].
 
--spec start_user(amoc:scenario(), amoc_scenario:user_id(), state()) ->
-    supervisor:startchild_ret().
-start_user(Scenario, Id, State) ->
+-spec start_user(amoc:scenario(), amoc_scenario:user_id(), non_neg_integer(),
+                 state()) -> supervisor:startchild_ret().
+start_user(Scenario, Id, Interarrival, State) ->
     R = supervisor:start_child(amoc_users_sup, [Scenario, Id, State]),
-    timer:sleep(interarrival()),
+    timer:sleep(Interarrival),
     R.
 
 -spec stop_users([amoc_scenario:user_id()], boolean()) -> [true | stop].

--- a/src/amoc_dist.erl
+++ b/src/amoc_dist.erl
@@ -52,6 +52,7 @@ do(Scenario, Start, End, Opts) ->
     _Step = proplists:get_value(step, Opts, 1),
 
     amoc_event:notify({dist_do, Scenario, Start, End, Opts}),
+    amoc_controller:start_scenario_checking(Scenario),
     Count = length(Nodes),
     [ amoc_controller:do(Node, Scenario, Start, End, Count, Id, Opts) ||
       {Id, Node} <- lists:zip(lists:seq(1, Count), Nodes) ].

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -5,6 +5,7 @@
 -module(amoc_scenario).
 
 -export_type([user_id/0, state/0]).
+-optional_callbacks([continue/0, terminate/1]).
 
 -type user_id() :: non_neg_integer().
 -type state() :: any().
@@ -16,3 +17,5 @@
 %% either start/1 or start/2 must be exported from the behaviour module
 -optional_callbacks([start/1, start/2]).
 
+-callback continue() -> continue | {stop, Reason :: term()}.
+-callback terminate(Reason :: term()) -> any().

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -5,7 +5,7 @@
 -module(amoc_scenario).
 
 -export_type([user_id/0, state/0]).
--optional_callbacks([continue/0, terminate/1]).
+-optional_callbacks([continue/0, terminate/1, next_user_batch/2]).
 
 -type user_id() :: non_neg_integer().
 -type state() :: any().
@@ -19,3 +19,6 @@
 
 -callback continue() -> continue | {stop, Reason :: term()}.
 -callback terminate(Reason :: term()) -> any().
+-callback next_user_batch(BatchIndex :: non_neg_integer(),
+                          PrevUserCount :: non_neg_integer()) ->
+    amoc_controller:user_batch_strategy().

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -5,7 +5,6 @@
 -module(amoc_scenario).
 
 -export_type([user_id/0, state/0]).
--optional_callbacks([continue/0, terminate/1, next_user_batch/2]).
 
 -type user_id() :: non_neg_integer().
 -type state() :: any().
@@ -13,12 +12,12 @@
 -callback init() -> {ok, state()} | ok | {error, Reason :: term()}.
 -callback start(user_id(), state()) -> any().
 -callback start(user_id()) -> any().
-
-%% either start/1 or start/2 must be exported from the behaviour module
--optional_callbacks([start/1, start/2]).
-
 -callback continue() -> continue | {stop, Reason :: term()}.
 -callback terminate(Reason :: term()) -> any().
 -callback next_user_batch(BatchIndex :: non_neg_integer(),
                           PrevUserCount :: non_neg_integer()) ->
     amoc_controller:user_batch_strategy().
+
+%% either start/1 or start/2 must be exported from the behaviour module
+-optional_callbacks([start/1, start/2]).
+-optional_callbacks([continue/0, terminate/1, next_user_batch/2]).

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -164,7 +164,7 @@ patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists(_
     %% then
     %% Maybe check Body, as answer format will be ready
     meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
-    meck:wait(amoc_controller, add_batches, ['sample_test1', 10], 2000),
+    meck:wait(amoc_controller, add_batches, [10, 'sample_test1'], 2000),
     ?assertEqual(200, CodeHttp).
 
 %% Helpers
@@ -207,7 +207,9 @@ mock_amoc_dist_do() ->
 -spec mock_amoc_controller_add_batches() -> ok.
 mock_amoc_controller_add_batches() ->
     ok = meck:new(amoc_controller, [unstick]),
-    Fun = fun(_,_) -> ok end,
+    Fun = fun(BatchCount, Scenario)
+                when is_integer(BatchCount) and is_atom(Scenario) -> ok
+          end,
     ok = meck:expect(amoc_controller, add_batches, Fun).
 
 -spec cleanup_amoc_dist() -> ok.

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -19,7 +19,8 @@
          get_scenario_status_returns_loaded_when_scenario_is_not_running/1,
          patch_scenario_returns_404_when_scenario_not_exists/1,
          patch_scenario_returns_400_when_malformed_request/1,
-         patch_scenario_returns_200_when_request_ok_and_module_exists/1
+         patch_scenario_returns_200_when_request_ok_and_module_exists/1,
+         patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists/1
         ]).
 
 
@@ -32,15 +33,22 @@ all() ->
      get_scenario_status_returns_loaded_when_scenario_is_not_running,
      patch_scenario_returns_404_when_scenario_not_exists,
      patch_scenario_returns_400_when_malformed_request,
-     patch_scenario_returns_200_when_request_ok_and_module_exists
+     patch_scenario_returns_200_when_request_ok_and_module_exists,
+     patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists
     ].
 
 init_per_testcase(
   patch_scenario_returns_200_when_request_ok_and_module_exists,
   Config) ->
-    ok = meck:new(amoc_dist, [unstick]),
-    Fun = fun(_,1,_) -> [ok] end,
-    ok = meck:expect(amoc_dist, do, Fun),
+    mock_amoc_dist_do(),
+    create_env(Config),
+    Config;
+
+init_per_testcase(
+  patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists,
+  Config) ->
+    mock_amoc_dist_do(),
+    mock_amoc_controller_add_batches(),
     create_env(Config),
     Config;
 
@@ -52,6 +60,13 @@ end_per_testcase(
   patch_scenario_returns_200_when_request_ok_and_module_exists,
   _Config) ->
     ok = meck:unload(amoc_dist),
+    destroy_env();
+
+end_per_testcase(
+  patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists,
+  _Config) ->
+    ok = meck:unload(amoc_dist),
+    ok = meck:unload(amoc_controller),
     destroy_env();
 
 end_per_testcase(_, _Config) ->
@@ -140,6 +155,17 @@ patch_scenario_returns_200_when_request_ok_and_module_exists(_Config) ->
     meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
     ?assertEqual(200, CodeHttp).
 
+patch_scenario_returns_200_when_request_with_user_batches_ok_and_module_exists(_Config) ->
+    %% given
+    RequestBody = jiffy:encode({[{users, 10}, {batches, 10}]}),
+    %% when
+    {CodeHttp, _Body} = amoc_api_helper:patch(
+                          ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
+    %% then
+    %% Maybe check Body, as answer format will be ready
+    meck:wait(amoc_dist, do, ['sample_test1', 1, 10], 2000),
+    meck:wait(amoc_controller, add_batches, ['sample_test1', 10], 2000),
+    ?assertEqual(200, CodeHttp).
 
 %% Helpers
 
@@ -171,6 +197,18 @@ data(Config, Path) ->
 given_amoc_dist_mocked_with_test_status(Value) ->
     meck:new(amoc_dist, [passtrough]),
     meck:expect(amoc_dist, test_status, fun(_) -> Value end).
+
+-spec mock_amoc_dist_do() -> ok.
+mock_amoc_dist_do() ->
+    ok = meck:new(amoc_dist, [unstick]),
+    Fun = fun(_,1,_) -> [ok] end,
+    ok = meck:expect(amoc_dist, do, Fun).
+
+-spec mock_amoc_controller_add_batches() -> ok.
+mock_amoc_controller_add_batches() ->
+    ok = meck:new(amoc_controller, [unstick]),
+    Fun = fun(_,_) -> ok end,
+    ok = meck:expect(amoc_controller, add_batches, Fun).
 
 -spec cleanup_amoc_dist() -> ok.
 cleanup_amoc_dist() ->

--- a/test/amoc_controller_SUITE.erl
+++ b/test/amoc_controller_SUITE.erl
@@ -1,0 +1,118 @@
+-module(amoc_controller_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([scenario_is_terminated_when_stopped/1,
+         scenario_is_not_terminated_when_not_stopped/1,
+         checking_will_not_start_when_any_callback_is_not_exported/1,
+         checking_callback_exceptions_are_caught/1
+        ]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     scenario_is_terminated_when_stopped,
+     scenario_is_not_terminated_when_not_stopped,
+     checking_will_not_start_when_any_callback_is_not_exported,
+     checking_callback_exceptions_are_caught
+    ].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(amoc),
+    ok = application:set_env(amoc, scenario_checking_interval, 0),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+scenario_is_terminated_when_stopped(_Config) ->
+    %% GIVEN
+    S = self(),
+    StopReason = make_ref(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> {stop, StopReason} end),
+    meck:expect(test_scenario, terminate, fun(Reason) -> S ! Reason end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    receive
+        Reason ->
+            ?assertMatch(StopReason, Reason)
+    end.
+
+scenario_is_not_terminated_when_not_stopped(_Config) ->
+    %% GIVEN
+    S = self(),
+    Ref = make_ref(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> continue end),
+    meck:expect(test_scenario, terminate, fun(_) -> S ! Ref end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    receive
+        RecvRef ->
+            ?assertNotMatch(Ref, RecvRef)
+    after
+        50 ->
+            true
+    end.
+
+checking_will_not_start_when_any_callback_is_not_exported(Config) ->
+    %% GIVEN
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> {stop, test} end),
+
+    %% WHEN
+    Res = amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    ?assertMatch(Res, skip).
+
+checking_callback_exceptions_are_caught(_Config) ->
+    %% GIVEN
+    S = self(),
+    meck:new(test_scenario, []),
+    meck:expect(test_scenario, continue, fun() -> error(continue) end),
+    meck:expect(test_scenario, terminate, fun(Reason) ->
+                                                  S ! Reason,
+                                                  error(terminate)
+                                          end),
+
+    %% WHEN
+    amoc_controller:start_scenario_checking(test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    receive
+        Reason ->
+            ?assertMatch({error, continue}, Reason)
+    after
+        50 ->
+            error(recv_assert_match_timeout)
+    end,
+    Apps = application:which_applications(),
+    ?assertNot(proplists:is_defined(amoc, Apps)).

--- a/test/amoc_controller_SUITE.erl
+++ b/test/amoc_controller_SUITE.erl
@@ -9,7 +9,12 @@
          scenario_is_terminated_when_stopped/1,
          scenario_is_not_terminated_when_not_stopped/1,
          checking_will_not_start_when_any_callback_is_not_exported/1,
-         checking_callback_exceptions_are_caught/1
+         checking_callback_exceptions_are_caught/1,
+         user_batches_are_added_according_to_strategy/1,
+         user_batches_number_can_be_limited/1,
+         user_batch_callback_receives_valid_parameters/1,
+         user_batches_respect_user_interarrival/1,
+         user_batches_will_not_be_added_when_callback_is_not_exported/1
         ]).
 
 %%--------------------------------------------------------------------
@@ -32,7 +37,8 @@
 
 all() ->
     [
-     {group, scenario_checking}
+     {group, scenario_checking},
+     {group, user_batches}
     ].
 
 groups() ->
@@ -43,6 +49,14 @@ groups() ->
        scenario_is_not_terminated_when_not_stopped,
        checking_will_not_start_when_any_callback_is_not_exported,
        checking_callback_exceptions_are_caught
+      ]},
+     {user_batches, [shuffle],
+      [
+       user_batches_are_added_according_to_strategy,
+       user_batches_number_can_be_limited,
+       user_batch_callback_receives_valid_parameters,
+       user_batches_respect_user_interarrival,
+       user_batches_will_not_be_added_when_callback_is_not_exported
       ]}
     ].
 
@@ -62,23 +76,55 @@ end_per_suite(Config) ->
 
 init_per_group(scenario_checking, Config) ->
     ok = application:set_env(amoc, scenario_checking_interval, 0),
+    Config;
+init_per_group(user_batches, Config) ->
+    ok = application:set_env(amoc, add_batch_interval, 0),
+    ok = application:set_env(amoc, interarrival, 0),
+    %% Mock supervisor:start_child/2 in order to change the behavior of
+    %% amoc_controller:start_user/4. Now a user is no longer a process but only
+    %% an entry in an ETS table. It simplifies testing substantially.
+    meck:new(supervisor, [unstick, passthrough, no_link]),
+    meck:expect(supervisor, start_child,
+                fun(amoc_users_sup, [_, Id, _]) ->
+                        ets:insert(amoc_users, {Id, self()});
+                   (Pid, Args) ->
+                        meck:passthrough([Pid, Args])
+                end),
     Config.
 
+end_per_group(user_batches, Config) ->
+    meck:unload(supervisor),
+    Config;
 end_per_group(_Group, Config) ->
     Config.
 
 init_per_testcase(checking_callback_exceptions_are_caught, Config) ->
     meck:new(application, [unstick, passthrough, no_link]),
     Config;
+init_per_testcase(Case, Config) when
+      Case == user_batches_are_added_according_to_strategy orelse
+      Case == user_batches_number_can_be_limited orelse
+      Case == user_batch_callback_receives_valid_parameters orelse
+      Case == user_batches_respect_user_interarrival ->
+    setup_amoc_controller(),
+    Config;
 init_per_testcase(_Case, Config) ->
     Config.
 
-end_per_testcase(checking_will_not_start_when_any_callback_is_not_exported,
-                 Config) ->
+end_per_testcase(Case, Config) when
+      Case == checking_will_not_start_when_any_callback_is_not_exported orelse
+      Case == user_batches_will_not_be_added_when_callback_is_not_exported ->
     meck:unload(test_scenario_no_exports),
     Config;
 end_per_testcase(checking_callback_exceptions_are_caught, Config) ->
     meck:unload(application),
+    Config;
+end_per_testcase(Case, Config) when
+      Case == user_batches_are_added_according_to_strategy orelse
+      Case == user_batches_number_can_be_limited orelse
+      Case == user_batch_callback_receives_valid_parameters orelse
+      Case == user_batches_respect_user_interarrival ->
+    reset_amoc_controller(),
     Config;
 end_per_testcase(_Case, Config) ->
     Config.
@@ -153,3 +199,103 @@ checking_callback_exceptions_are_caught(_Config) ->
     %% THEN
     timer:sleep(100),
     [?recvAssertMatch(P) || P <- [{error, continue}, amoc_stopped]].
+
+%%--------------------------------------------------------------------
+%% GROUP user_batches
+%%--------------------------------------------------------------------
+
+user_batches_are_added_according_to_strategy(_Config) ->
+    %% GIVEN
+    Node1Users = 10,
+    Node2Users = 20,
+    TotalUsers = Node1Users + Node2Users,
+    BatchStrategy = [{node(), Node1Users, 0},
+                     {node(), Node2Users, 0}],
+    BatchCount = 1,
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertMatch(TotalUsers,
+                 proplists:get_value(count, amoc_controller:users())).
+
+user_batches_number_can_be_limited(_Config) ->
+    %% GIVEN
+    UserCount = 1,
+    BatchStrategy = [{node(), UserCount, 0}],
+    BatchCount = 10,
+    TotalUsers = UserCount * BatchCount,
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertMatch(TotalUsers,
+                 proplists:get_value(count, amoc_controller:users())).
+
+user_batch_callback_receives_valid_parameters(_Config) ->
+    %% GIVEN
+    S = self(),
+    BatchIndexWithUserCount =
+        [{X, rand:uniform(10)} || X <- lists:seq(2,10)], %% {BatchIndex, UserCount}
+    BatchCount = length(BatchIndexWithUserCount) + 1,
+    meck:expect(test_scenario, next_user_batch,
+                fun(BatchIndex, PrevUserCount) ->
+                        S ! {BatchIndex, PrevUserCount},
+                        {_, UserCount} =
+                            lists:nth(BatchIndex,
+                                      BatchIndexWithUserCount ++ [{0,0}]),
+                        [{node(), UserCount, 0}]
+                end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    [?recvAssertMatch({BatchIndex, PrevUserCount})
+     || {BatchIndex, PrevUserCount} <- [{1,0}] ++ BatchIndexWithUserCount].
+
+user_batches_respect_user_interarrival(_Config) ->
+    %% GIVEN
+    UserCount = 2,
+    BatchCount = 1,
+    Interarrival = 1000,
+    BatchStrategy = [{node(), UserCount, Interarrival}],
+    meck:expect(test_scenario, next_user_batch, fun(_, _) -> BatchStrategy end),
+
+    %% WHEN
+    amoc_controller:add_batches(BatchCount, test_scenario),
+
+    %% THEN
+    timer:sleep(100),
+    ?assertNotMatch(UserCount, ets:info(amoc_users, size)).
+
+user_batches_will_not_be_added_when_callback_is_not_exported(_Config) ->
+    %% GIVEN
+    meck:new(test_scenario_no_exports, [non_strict]),
+
+    %% WHEN
+    Res = amoc_controller:add_batches(1, test_scenario_no_exports),
+
+    %% THEN
+    ?assertMatch(Res, skip).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+remove_all_users() ->
+    ets:delete_all_objects(amoc_users).
+
+setup_amoc_controller() ->
+    amoc_controller:do(test_scenario, 1, 2),
+    timer:sleep(100),
+    remove_all_users().
+
+reset_amoc_controller() ->
+    exit(whereis(amoc_controller), kill).

--- a/test/amoc_controller_SUITE_data/test_scenario.erl
+++ b/test/amoc_controller_SUITE_data/test_scenario.erl
@@ -1,0 +1,6 @@
+-module(test_scenario).
+-compile(export_all).
+
+continue() -> ok.
+
+terminate(_) -> ok.

--- a/test/amoc_controller_SUITE_data/test_scenario.erl
+++ b/test/amoc_controller_SUITE_data/test_scenario.erl
@@ -1,6 +1,0 @@
--module(test_scenario).
--compile(export_all).
-
-continue() -> ok.
-
-terminate(_) -> ok.


### PR DESCRIPTION
This branch was originally created for storing helpers that are considered relevant for load testing MongooseIM on AWS, however, @michalwski has suggested someone else might find these helpful as well hence the PR.

Main enhancements:

1.  **Allow to terminate a scenario at any time**
It's now possible to terminate a scenario at any moment via two
new scenario callbacks `continue/0` and `terminate/1`. The former
checks if the current scenario is still valid e.g. some metrics are
below a certain treshold and must return `continue` or `{stop, Reason}`.
The latter one implements the actual termination. It's called only
if `continue/0` returned `{stop, Reason}`. The reason is passed to
the terminate callback. When `continue` is returned nothing happens.
The both callbacks are optional. Checking scenario state is scheduled
only if both of them are implemented. By default, checking interval
equals 60s. It can be changed by setting `scenario_checking_interval`
application environment.
Checking logic happens in `amoc_controller` process only on a
"master" Amoc node and only in "distributed mode" (scenario has
to be started via `amoc_dist:do/3/4`).

2. **Make it possible to add users in batches**
There is new `amoc_controller:add_batches/2` function that allows to add
users in batches according to some strategy. The function takes the
scenario module and the number of batches as parameters.
The strategy of adding users should be returned by `next_user_batch/2`
callback implemented in the scenario module. The callback is optional.
The batch index and the number of users added in the previous batch are
parmeters that are passed to the callback function.  The strategy is a
list of {Node, NumOfUsers, Interarrival}.
Batches are added every batch interval specified by `add_batch_interval`
application environment variable, which is 5 minutes by default.
Adding batches can be sheduled via HTTP API by specifying `batches` key
in a body request to `scenarios/$SCENARIO` endpoint.