### PR TITLE
Amoc throttle rework

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
            ]}.
 
     {relx, [
-        {release, {amoc, "0.9.0"}, [amoc, inets]},
+        {release, {amoc, "0.9.0"}, [amoc, inets, runtime_tools]},
         {dev_mode, false},
         {include_erts, true},
         {include_src, false},

--- a/scenarios/throttle_test.erl
+++ b/scenarios/throttle_test.erl
@@ -32,19 +32,31 @@ init() ->
             amoc_throttle:change_rate_gradually(?RATE_CHANGE_TEST,
                                                 20000, 1750, 60000, 200000, 2),
             timer:sleep(100000),
-            amoc_throttle:resume(?RATE_CHANGE_TEST)
+            amoc_throttle:resume(?RATE_CHANGE_TEST),
+            timer:sleep(480000), % 8 mins
+            amoc_throttle:change_rate(?RATE_CHANGE_TEST, 20019, 60000)
         end),
     ok.
 
 -spec start(amoc_scenario:user_id()) -> any().
-start(1) -> parallel_execution_scenario();
+start(1) ->
+    MasterNode = amoc_slave:get_master_node(),
+    Pid = spawn(MasterNode, fun count_per_minute/0),
+    rpc:call(MasterNode, erlang, register, [count_per_minute, Pid]),
+    parallel_execution_scenario();
 start(_Id) -> rate_change_scenario().
 
+%%-------------------------------------------------------------------
+%% Internal functions
+%%-------------------------------------------------------------------
+
+%% metrics initialisation
 init_metrics() ->
     amoc_metrics:init(times, execution_delay).
 
 rate_change_scenario() ->
     {TimeDiff, _} = timer:tc(fun rate_change_fn/0),
+    {count_per_minute, amoc_slave:get_master_node()} ! inc,
     amoc_metrics:update_time(execution_delay, TimeDiff),
     rate_change_scenario().
 
@@ -52,7 +64,8 @@ rate_change_fn() ->
     amoc_throttle:send_and_wait(?RATE_CHANGE_TEST, some_msg).
 
 parallel_execution_scenario() ->
-    [parallel_execution_fn() || _ <- lists:seq(0, 10000)],
+    Pid = spawn(fun max_counter_value/0),
+    [parallel_execution_fn(Pid) || _ <- lists:seq(0, 10000)],
     timer:sleep(200000), %% 40 executions per minute
     amoc_throttle:pause(?PARALLEL_EXECUTION_TEST),
     timer:sleep(150000), %% 0 executions per minute
@@ -63,6 +76,44 @@ parallel_execution_scenario() ->
     amoc_throttle:change_rate(?PARALLEL_EXECUTION_TEST, 30, 0),
     timer:sleep(infinity). %% 60 executions per minute, and then 0
 
-parallel_execution_fn() ->
+parallel_execution_fn(Pid) ->
     %% just sleep 30 seconds
-    amoc_throttle:run(?PARALLEL_EXECUTION_TEST, fun() -> timer:sleep(30000) end).
+    amoc_throttle:run(?PARALLEL_EXECUTION_TEST,
+                      fun() ->
+                          Pid ! {delta, 1},
+                          timer:sleep(30000),
+                          Pid ! {delta, -1}
+                      end).
+
+max_counter_value() ->
+    amoc_metrics:init(gauge, max_scheduled),
+    amoc_metrics:init(gauge, current_scheduled),
+    max_counter_value(0, 0).
+
+max_counter_value(Gauge, MaxGauge) when Gauge > MaxGauge ->
+    amoc_metrics:update_gauge(max_scheduled, Gauge),
+    max_counter_value(Gauge, Gauge);
+max_counter_value(Gauge, MaxGauge) ->
+    receive
+        {delta, N} ->
+            amoc_metrics:update_gauge(current_scheduled, Gauge + N),
+            max_counter_value(Gauge + N, MaxGauge)
+    end.
+
+count_per_minute() ->
+    %%this one runs on master amoc node
+    amoc_metrics:init(gauge, scheduled_per_minute),
+    erlang:send_after(60000, self(), one_minute),
+    count_per_minute(0).
+
+count_per_minute(N) ->
+    receive
+        inc ->
+            count_per_minute(N + 1);
+        one_minute ->
+            erlang:send_after(60000, self(), one_minute),
+            amoc_metrics:update_gauge(scheduled_per_minute, N),
+            count_per_minute(0)
+    end.
+
+

--- a/scenarios/throttle_test.erl
+++ b/scenarios/throttle_test.erl
@@ -25,12 +25,12 @@ init() ->
         fun() ->
             timer:sleep(200000),
             amoc_throttle:change_rate_gradually(?RATE_CHANGE_TEST,
-                                                1750, 21500, 60000, 200000, 5),
+                                                1750, 21500, 60000, 200000, 4),
             timer:sleep(950000),
             amoc_throttle:pause(?RATE_CHANGE_TEST),
             timer:sleep(100000),
             amoc_throttle:change_rate_gradually(?RATE_CHANGE_TEST,
-                                                20000, 1750, 60000, 200000, 3),
+                                                20000, 1750, 60000, 200000, 2),
             timer:sleep(100000),
             amoc_throttle:resume(?RATE_CHANGE_TEST)
         end),
@@ -53,15 +53,15 @@ rate_change_fn() ->
 
 parallel_execution_scenario() ->
     [parallel_execution_fn() || _ <- lists:seq(0, 10000)],
-    timer:sleep(200000),
+    timer:sleep(200000), %% 40 executions per minute
     amoc_throttle:pause(?PARALLEL_EXECUTION_TEST),
-    timer:sleep(150000),
+    timer:sleep(150000), %% 0 executions per minute
     amoc_throttle:resume(?PARALLEL_EXECUTION_TEST),
-    timer:sleep(100000),
+    timer:sleep(100000), %% 40 executions per minute
     amoc_throttle:change_rate(?PARALLEL_EXECUTION_TEST, 20, 60000),
-    timer:sleep(150000),
+    timer:sleep(150000), %% 20 executions per minute
     amoc_throttle:change_rate(?PARALLEL_EXECUTION_TEST, 30, 0),
-    timer:sleep(infinity).
+    timer:sleep(infinity). %% 60 executions per minute, and then 0
 
 parallel_execution_fn() ->
     %% just sleep 30 seconds

--- a/src/amoc_dist.erl
+++ b/src/amoc_dist.erl
@@ -46,6 +46,7 @@ test_status(ScenarioName) ->
          amoc:do_opts()) -> [any()].
 do(Scenario, Start, End, Opts) ->
     Nodes = proplists:get_value(nodes, Opts, amoc_nodes()),
+    [amoc_slave:monitor_master(Node) || Node <- [node() | Nodes]],
 
     _InterArrival = proplists:get_value(interarrival, Opts, 75),
     _RepeatTimeout = proplists:get_value(repeat, Opts, 75),

--- a/src/amoc_slave.erl
+++ b/src/amoc_slave.erl
@@ -13,7 +13,8 @@
          start/2,
          monitor_master/1,
          ping/1,
-         node_name/1]).
+         node_name/1,
+         get_master_node/0]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
@@ -54,6 +55,13 @@ ping(Node) ->
 start(Host, Directory) ->
     gen_server:call(?SERVER, {start, Host, Directory}).
 
+-spec get_master_node() -> node().
+get_master_node() ->
+    case gen_server:call(?SERVER, get_master_node) of
+        undefined -> node();
+        MasterNode -> MasterNode
+    end.
+
 -spec monitor_master(node()) -> ok.
 monitor_master(Node) ->
     gen_server:call({?SERVER, Node}, {monitor_master, node()}).
@@ -75,6 +83,8 @@ init([]) ->
 handle_call({start, Host, Directory}, _From, State) ->
     State1 = handle_start(Host, Directory, State),
     {reply, ok, State1};
+handle_call(get_master_node, _From, #state{master = Master} = State) ->
+    {reply, Master, State};
 handle_call({monitor_master, Master}, _From, State) ->
     true = erlang:monitor_node(Master, true),
     {reply, ok, State#state{master = Master}};

--- a/src/amoc_sup.erl
+++ b/src/amoc_sup.erl
@@ -33,13 +33,14 @@ start_link() ->
          }}.
 init([]) ->
     amoc_users = start_users_ets(),
-    {ok, { {one_for_one, 5, 10},
-           [
+    {ok, {{one_for_one, 5, 10},
+        [
             ?CHILD(amoc_event, worker),
             ?CHILD(amoc_users_sup, supervisor),
             ?CHILD(amoc_controller, worker),
-            ?CHILD(amoc_slave, worker)
-           ]} }.
+            ?CHILD(amoc_slave, worker),
+            ?CHILD(amoc_throttle_controller, worker)
+        ]}}.
 
 -spec start_users_ets() -> ets:tid() | atom().
 start_users_ets() ->

--- a/src/amoc_throttle.erl
+++ b/src/amoc_throttle.erl
@@ -56,34 +56,32 @@ run(Name, Fn) ->
     %% Diagram showing function execution flow in distributed env.
     %% generated using https://sequencediagram.org/ (remove "%%"):
     %%
-    %% 	  title Amoc distributed
-    %%    participantgroup  **Slave node**
-    %%        participant User
-    %%        participant Async runner
-    %%    end
-    %%    participantgroup **Master node**
-    %%        participant Throttle process
-    %%    end
-    %%    box left of User: inc req rate
+    %%        title Amoc distributed
+    %%        participantgroup  **Slave node**
+    %%            participant User
+    %%            participant Async runner
+    %%        end
+    %%        participantgroup **Master node**
+    %%            participant Throttle process
+    %%        end
+    %%        box left of User: inc req rate
     %%
-    %%    User -> *Async runner : Fun
+    %%        User -> *Async runner : Fun
     %%
-    %%    User -> Throttle process : {schedule, Async runner PID}
-    %%    box right of Throttle process : inc req rate
+    %%        User -> Throttle process : {schedule, Async runner PID}
+    %%        box right of Throttle process : inc req rate
     %%
     %%        ==throtlling delay==
     %%
-    %%    Throttle process -> Async runner:{scheduled, Throttle process PID, Interval}
+    %%        Throttle process -> Async runner: scheduled
     %%
-    %%    box left of Async runner : inc exec rate
-    %%    abox over Async runner : Fun()
-    %%    activate Async runner
-    %%    box right of Throttle process : inc exec rate
-    %%    deactivate Async runner
-    %%    Async runner -> Throttle process : increase n
-    %%    space 1
-    %%
-    %%    destroy Async runner
+    %%        box left of Async runner : inc exec rate
+    %%        abox over Async runner : Fun()
+    %%        activate Async runner
+    %%        box right of Throttle process : inc exec rate
+    %%        deactivate Async runner
+    %%        Async runner ->Throttle process:'DOWN'
+    %%        destroy Async runner
     %%
     %% for the local execution, req/exec rates are increased only by throttle process.
 

--- a/src/amoc_throttle.erl
+++ b/src/amoc_throttle.erl
@@ -20,9 +20,9 @@
 
 -define(DEFAULT_INTERVAL, 60000).%% one minute
 
--define(RATE(Name), [throttle, Name, rate]).
--define(EXEC_RATE(Name), [throttle, Name, exec_rate]).
--define(REQ_RATE(Name), [throttle, Name, req_rate]).
+-define(RATE(Name), {strict, [throttle, Name, rate]}).
+-define(EXEC_RATE(Name), {strict, [throttle, Name, exec_rate]}).
+-define(REQ_RATE(Name), {strict, [throttle, Name, req_rate]}).
 
 -type name() :: atom().
 

--- a/src/amoc_throttle.erl
+++ b/src/amoc_throttle.erl
@@ -19,11 +19,6 @@
          stop/1]).
 
 -define(DEFAULT_INTERVAL, 60000).%% one minute
-
--define(RATE(Name), {strict, [throttle, Name, rate]}).
--define(EXEC_RATE(Name), {strict, [throttle, Name, exec_rate]}).
--define(REQ_RATE(Name), {strict, [throttle, Name, req_rate]}).
-
 -type name() :: atom().
 
 -spec start(name(), pos_integer()) -> ok | {error, any()}.
@@ -36,67 +31,28 @@ start(Name, Rate, Interval) ->
 
 -spec start(name(), pos_integer(), non_neg_integer(), pos_integer()) -> ok | {error, any()}.
 start(Name, Rate, Interval, NoOfProcesses) ->
-    case pg2:get_members(Name) of
-        {error, {no_such_group, Name}} ->
-            pg2:create(Name),
-            amoc_metrics:init(gauge, ?RATE(Name)),
-            [amoc_metrics:init(counters, E) || E <- [?EXEC_RATE(Name), ?REQ_RATE(Name)]],
-            RatePerMinute = rate_per_minute(Rate, Interval),
-            amoc_metrics:update_gauge(?RATE(Name), RatePerMinute),
-            RealNoOfProcesses = min(Rate, NoOfProcesses),
-            start_throttle_processes(Name, Interval, Rate, RealNoOfProcesses),
-            ok;
-        List when is_list(List) ->
-            {error, {name_is_already_used, Name}}
-    end.
+    amoc_throttle_controller:ensure_throttle_processes_started(Name, Rate, Interval, NoOfProcesses).
 
 -spec pause(name()) -> ok | {error, any()}.
 pause(Name) ->
-    all_processes(Name, pause).
+    amoc_throttle_controller:pause(Name).
 
 -spec resume(name()) -> ok | {error, any()}.
 resume(Name) ->
-    all_processes(Name, resume).
+    amoc_throttle_controller:resume(Name).
 
 -spec change_rate(name(), pos_integer(), non_neg_integer()) -> ok | {error, any()}.
 change_rate(Name, Rate, Interval) ->
-    case pg2:get_members(Name) of
-        {error, Err} -> {error, Err};
-        List when is_list(List) ->
-            RatePerMinute = rate_per_minute(Rate, Interval),
-            amoc_metrics:update_gauge(?RATE(Name), RatePerMinute),
-            update_throttle_processes(List, Interval, Rate, length(List))
-    end.
+    amoc_throttle_controller:change_rate(Name, Rate, Interval).
 
 -spec change_rate_gradually(name(), pos_integer(), pos_integer(),
                             non_neg_integer(), pos_integer(), pos_integer()) -> ok | {error, any()}.
-change_rate_gradually(Name, _, HighRate, RateInterval, _, 1) ->
-    change_rate(Name, HighRate, RateInterval), ok;
 change_rate_gradually(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps) ->
-    change_rate(Name, LowRate, RateInterval),
-    Step = (HighRate - LowRate) div (NoOfSteps - 1),
-    NewLowRate = LowRate + Step,
-    spawn(
-        fun() ->
-            timer:sleep(StepInterval),
-            change_rate_gradually(Name, NewLowRate, HighRate, RateInterval, StepInterval, NoOfSteps - 1)
-        end),
-    ok.
+    amoc_throttle_controller:change_rate_gradually(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps).
 
 -spec run(name(), fun(()-> any())) -> ok | {error, any()}.
 run(Name, Fn) ->
-    case get_throttle_process(Name) of
-        {ok, Pid} ->
-            amoc_metrics:update_counter(?REQ_RATE(Name)),
-            Fun =
-                fun() ->
-                    amoc_metrics:update_counter(?EXEC_RATE(Name)),
-                    Fn()
-                end,
-            amoc_throttle_process:run(Pid, Fun),
-            ok;
-        Error -> Error
-    end.
+    amoc_throttle_controller:run(Name, Fn).
 
 -spec send(name(), pid(), any()) -> ok | {error, any()}.
 send(Name, Pid, Msg) ->
@@ -115,53 +71,5 @@ send_and_wait(Name, Msg) ->
 
 -spec stop(name()) -> ok | {error, any()}.
 stop(Name) ->
-    all_processes(Name, stop),
-    pg2:delete(Name),
+    amoc_throttle_controller:stop(Name),
     ok.
-
-all_processes(Name, Cmd) ->
-    case pg2:get_members(Name) of
-        List when is_list(List) ->
-            [run_cmd(P, Cmd) || P <- List], ok;
-        Error -> Error
-    end.
-
-run_cmd(Pid, stop) ->
-    amoc_throttle_process:stop(Pid);
-run_cmd(Pid, pause) ->
-    amoc_throttle_process:pause(Pid);
-run_cmd(Pid, resume) ->
-    amoc_throttle_process:resume(Pid).
-
-rate_per_minute(_, 0) -> 0;
-rate_per_minute(Rate, Interval) ->
-    (Rate * 60000) div Interval.
-
-start_throttle_processes(Name, Interval, Rate, 1) ->
-    start_throttle_process(Name, Interval, Rate);
-start_throttle_processes(Name, Interval, Rate, N) when is_integer(N), N > 1 ->
-    ProcessRate = Rate div N,
-    start_throttle_process(Name, Interval, ProcessRate),
-    start_throttle_processes(Name, Interval, Rate - ProcessRate, N - 1).
-
-start_throttle_process(Name, Interval, Rate) ->
-    {ok, Pid} = amoc_throttle_process:start(Interval, Rate),
-    pg2:join(Name, Pid).
-
-update_throttle_processes([Pid], Interval, Rate, 1) ->
-    amoc_throttle_process:update(Pid, Interval, Rate);
-update_throttle_processes([Pid | Tail], Interval, Rate, N) when N > 1 ->
-    ProcessRate = Rate div N,
-    amoc_throttle_process:update(Pid, Interval, ProcessRate),
-    update_throttle_processes(Tail, Interval, Rate - ProcessRate, N - 1).
-
-get_throttle_process(Name) ->
-    case pg2:get_members(Name) of
-        [] ->
-            {error, {no_trottle_process_registered, Name}};
-        {error, Error} ->
-            {error, Error};
-        List -> %% nonempty list
-            N = rand:uniform(length(List)),
-            {ok, lists:nth(N, List)}
-    end.

--- a/src/amoc_throttle.erl
+++ b/src/amoc_throttle.erl
@@ -52,6 +52,42 @@ change_rate_gradually(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfS
 
 -spec run(name(), fun(()-> any())) -> ok | {error, any()}.
 run(Name, Fn) ->
+
+    %% Diagram showing function execution flow in distributed env.
+    %% generated using https://sequencediagram.org/ (remove "%%"):
+    %%
+    %% 	  title Amoc distributed
+    %%    participantgroup  **Slave node**
+    %%        participant User
+    %%        participant Async runner
+    %%    end
+    %%    participantgroup **Master node**
+    %%        participant Throttle process
+    %%    end
+    %%    box left of User: inc req rate
+    %%
+    %%    User -> *Async runner : Fun
+    %%
+    %%    User -> Throttle process : {schedule, Async runner PID}
+    %%    box right of Throttle process : inc req rate
+    %%
+    %%        ==throtlling delay==
+    %%
+    %%    Throttle process -> Async runner:{scheduled, Throttle process PID, Interval}
+    %%
+    %%    box left of Async runner : inc exec rate
+    %%    abox over Async runner : Fun()
+    %%    activate Async runner
+    %%    box right of Throttle process : inc exec rate
+    %%    deactivate Async runner
+    %%    Async runner -> Throttle process : increase n
+    %%    space 1
+    %%
+    %%    destroy Async runner
+    %%
+    %% for the local execution, req/exec rates are increased only by throttle process.
+
+
     amoc_throttle_controller:run(Name, Fn).
 
 -spec send(name(), pid(), any()) -> ok | {error, any()}.

--- a/src/amoc_throttle_controller.erl
+++ b/src/amoc_throttle_controller.erl
@@ -209,8 +209,15 @@ change_rate_and_stop_plan(Name, State) ->
     HighRate = Plan#change_rate_plan.high_rate,
 
     {ok, HighRate} = do_change_rate(Name, HighRate, Interval),
-    timer:cancel(TRef),
+    {ok, cancel} = timer:cancel(TRef),
+    consume_all_timer_ticks({change_plan, Name}),
     State#{Name => Info#throttle_info{rate = HighRate, change_plan = undefined}}.
+
+consume_all_timer_ticks(Msg) ->
+    receive
+        Msg -> consume_all_timer_ticks(Msg)
+    after 0 -> ok
+    end.
 
 -spec continue_plan(name(), state()) -> state().
 continue_plan(Name, State) ->

--- a/src/amoc_throttle_controller.erl
+++ b/src/amoc_throttle_controller.erl
@@ -1,0 +1,318 @@
+-module(amoc_throttle_controller).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0,
+         ensure_throttle_processes_started/4,
+         pause/1, resume/1, stop/1,
+         change_rate/3, change_rate_gradually/6,
+         run/2, update_metric/2]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2]).
+
+-define(SERVER, ?MODULE).
+-define(MASTER_SERVER, {?SERVER, amoc_slave:get_master_node()}).
+
+-define(RATE(Name), {strict, [throttle, Name, rate]}).
+-define(EXEC_RATE(Name), {strict, [throttle, Name, exec_rate]}).
+-define(REQ_RATE(Name), {strict, [throttle, Name, req_rate]}).
+
+-record(throttle_info, {
+    rate :: non_neg_integer(),
+    interval :: non_neg_integer(),
+    no_of_procs :: pos_integer(),
+    active :: boolean(),
+    change_plan :: change_rate_plan() | undefined
+}).
+
+-record(change_rate_plan, {
+    high_rate :: pos_integer(),
+    no_of_steps :: non_neg_integer(),
+    timer :: timer:tref()}).
+
+-type name() :: atom().
+-type change_rate_plan() :: #change_rate_plan{}.
+-type throttle_info() :: #throttle_info{}.
+-type state() :: #{name() => throttle_info()}.
+%%%===================================================================
+%%% API
+%%%===================================================================
+-spec(start_link() ->
+    {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec(ensure_throttle_processes_started(name(), non_neg_integer(), non_neg_integer(), pos_integer()) ->
+    {ok, started_throttle_processes} |
+    {ok, throttle_processes_already_started} |
+    {error, any()}).
+ensure_throttle_processes_started(Name, Interval, Rate, NoOfProcesses) ->
+    case {amoc_slave:get_master_node(), node()} of
+        {N, N} -> ok;
+        _ -> [amoc_metrics:init(counters, E) || E <- [?EXEC_RATE(Name), ?REQ_RATE(Name)]]
+    end,
+    gen_server:call(?MASTER_SERVER, {start_processes, Name, Interval, Rate, NoOfProcesses}).
+
+-spec run(name(), fun(()-> any())) -> ok | {error, any()}.
+run(Name, Fn) ->
+    case get_throttle_process(Name) of
+        {ok, Pid} ->
+            maybe_update_metric(Name, request),
+            Fun =
+            fun() ->
+                maybe_update_metric(Name, execution),
+                Fn()
+            end,
+            amoc_throttle_process:run(Pid, Fun),
+            ok;
+        Error -> Error
+    end.
+
+-spec pause(name()) -> ok | {error, any()}.
+pause(Name) ->
+    gen_server:call(?MASTER_SERVER, {pause, Name}).
+
+-spec resume(name()) -> ok | {error, any()}.
+resume(Name) ->
+    gen_server:call(?MASTER_SERVER, {resume, Name}).
+
+-spec change_rate(name(), pos_integer(), non_neg_integer()) -> ok | {error, any()}.
+change_rate(Name, Rate, Interval) ->
+    gen_server:call(?MASTER_SERVER, {change_rate, Name, Rate, Interval}).
+
+-spec change_rate_gradually(name(), pos_integer(), pos_integer(),
+                            non_neg_integer(), pos_integer(), pos_integer()) -> ok | {error, any()}.
+change_rate_gradually(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps) ->
+    gen_server:call(?MASTER_SERVER, {change_rate_gradually, Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps}).
+
+-spec stop(name()) -> ok | {error, any()}.
+stop(Name) ->
+    gen_server:call(?MASTER_SERVER, {stop, Name}).
+
+-spec update_metric(name(), execution | request) -> ok.
+update_metric(Name, execution) ->
+    amoc_metrics:update_counter(?EXEC_RATE(Name));
+update_metric(Name, request) ->
+    amoc_metrics:update_counter(?REQ_RATE(Name)).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+-spec init([]) -> {ok, #{}}.
+init([]) ->
+    {ok, #{}}.
+
+-spec handle_call({start_processes, name(), pos_integer(), non_neg_integer(), pos_integer()},
+                  From :: {pid(), Tag :: term()}, state()) ->
+                     {reply, {ok, started}, state()} |
+                     {reply, {error, wrong_no_of_procs}, state()};
+                 ({pause | resume | stop}, From :: {pid(), Tag :: term()}, state()) ->
+                     {reply, ok, state()} |
+                     {reply, Error :: any(), state()};
+                 ({change_rate, name(), pos_integer(), non_neg_integer()},
+                  From :: {pid(), Tag :: term()}, state()) ->
+                     {reply, ok, state()} |
+                     {reply, {error, any()}, state()};
+                 ({change_rate_gradually, name(), pos_integer(), pos_integer(), non_neg_integer(), pos_integer(), pos_integer()},
+                  From :: {pid(), Tag :: term()}, state()) ->
+                     {reply, ok, state()} |
+                     {reply, {error, any()}, state()}.
+handle_call({start_processes, Name, Rate, Interval, NoOfProcesses}, _From, State) ->
+    case pg2:get_members(Name) of
+        {error, {no_such_group, Name}} ->
+            RealNoOfProcesses = start_processes(Name, Rate, Interval, NoOfProcesses),
+            {reply, {ok, started},
+             State#{Name => #throttle_info{rate = Rate, interval = Interval, no_of_procs = RealNoOfProcesses, active = true}}};
+        Group when is_list(Group) ->
+            ExpectedNoOfProcesses = min(Rate, NoOfProcesses),
+            case length(Group) of
+                ExpectedNoOfProcesses -> {reply, {ok, started}, State};
+                _ -> {reply, {error, wrong_no_of_procs}, State}
+            end
+    end;
+handle_call({pause, Name}, _From, State) ->
+    case all_processes(Name, pause) of
+        ok ->
+            Info = maps:get(Name, State),
+            {reply, ok, State#{Name => Info#throttle_info{active = false}}};
+        Error -> {reply, Error, State}
+    end;
+handle_call({resume, Name}, _From, State) ->
+    case all_processes(Name, resume) of
+        ok ->
+            Info = maps:get(Name, State),
+            {reply, ok, State#{Name => Info#throttle_info{active = true}}};
+        Error -> {reply, Error, State}
+    end;
+handle_call({change_rate, Name, Rate, Interval}, _From, State) ->
+    Info = maps:get(Name, State),
+    case maybe_change_rate(Name, Rate, Interval, Info) of
+        {ok, Rate} -> UpdatedInfo = Info#throttle_info{rate = Rate, interval = Interval},
+            {reply, ok, State#{Name => UpdatedInfo}};
+        Error -> {reply, Error, State}
+    end;
+handle_call({change_rate_gradually, Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps}, _From, State) ->
+    Info = maps:get(Name, State),
+    case Info#throttle_info.change_plan of
+        undefined ->
+            NewInfo = start_gradual_rate_change(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps, Info),
+            {reply, ok, State#{Name => NewInfo}};
+        _ -> {reply, {error, cannot_change_rate}, State}
+    end;
+handle_call({stop, Name}, _From, State) ->
+    case all_processes(Name, stop) of
+        ok ->
+            pg2:delete(Name),
+            {reply, ok, maps:remove(Name, State)};
+        Error -> {reply, Error, State}
+    end.
+
+-spec(handle_cast(any(), state()) -> {noreply, state()}).
+handle_cast(_, State) ->
+    {noreply, State}.
+
+-spec(handle_info({change_plan, name()}, state()) ->
+    {noreply, state()}).
+handle_info({change_plan, Name}, State) ->
+    Info = maps:get(Name, State),
+    Plan = Info#throttle_info.change_plan,
+    case Plan#change_rate_plan.no_of_steps of
+        1 -> NewState = change_rate_and_stop_plan(Name, State),
+            {noreply, NewState};
+        N when N > 1 -> NewState = continue_plan(Name, State),
+            {noreply, NewState}
+    end.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+maybe_update_metric(Name, Type) ->
+    case {amoc_slave:get_master_node(), node()} of
+        {N, N} -> ok;
+        _ -> update_metric(Name, Type)
+    end.
+
+-spec change_rate_and_stop_plan(name(), state()) -> state().
+change_rate_and_stop_plan(Name, State) ->
+    Info = maps:get(Name, State),
+    Plan = Info#throttle_info.change_plan,
+    Interval = Info#throttle_info.interval,
+    TRef = Plan#change_rate_plan.timer,
+    HighRate = Plan#change_rate_plan.high_rate,
+
+    {ok, HighRate} = do_change_rate(Name, HighRate, Interval),
+    timer:cancel(TRef),
+    State#{Name => Info#throttle_info{rate = HighRate, change_plan = undefined}}.
+
+-spec continue_plan(name(), state()) -> state().
+continue_plan(Name, State) ->
+    Info = maps:get(Name, State),
+    Plan = Info#throttle_info.change_plan,
+    LowRate = Info#throttle_info.rate,
+    HighRate = Plan#change_rate_plan.high_rate,
+    NoOfSteps = Plan#change_rate_plan.no_of_steps,
+
+    Step = (HighRate - LowRate) div (NoOfSteps),
+    NewRate = LowRate + Step,
+    {ok, NewRate} = do_change_rate(Name, NewRate, Info#throttle_info.interval),
+
+    NewPlan = Plan#change_rate_plan{no_of_steps = NoOfSteps - 1},
+    State#{Name => Info#throttle_info{rate = NewRate, change_plan = NewPlan}}.
+
+-spec rate_per_minute(pos_integer(), non_neg_integer()) -> non_neg_integer().
+rate_per_minute(_, 0) -> 0;
+rate_per_minute(Rate, Interval) ->
+    (Rate * 60000) div Interval.
+
+-spec start_processes(name(), pos_integer(), non_neg_integer(), pos_integer()) -> pos_integer().
+start_processes(Name, Rate, Interval, NoOfProcesses) ->
+    pg2:create(Name),
+    % Master metrics
+    amoc_metrics:init(gauge, ?RATE(Name)),
+    [amoc_metrics:init(counters, E) || E <- [?EXEC_RATE(Name), ?REQ_RATE(Name)]],
+    RatePerMinute = rate_per_minute(Rate, Interval),
+    amoc_metrics:update_gauge(?RATE(Name), RatePerMinute),
+    RealNoOfProcesses = min(Rate, NoOfProcesses),
+    start_throttle_processes(Name, Interval, Rate, RealNoOfProcesses),
+    RealNoOfProcesses.
+
+-spec get_throttle_process(name()) -> {error, {no_throttle_process_registered, name()}} |
+{error, any()} | {ok, pid()}.
+get_throttle_process(Name) ->
+    case pg2:get_members(Name) of
+        [] ->
+            {error, {no_throttle_process_registered, Name}};
+        {error, Error} ->
+            {error, Error};
+        List -> %% nonempty list
+            N = rand:uniform(length(List)),
+            {ok, lists:nth(N, List)}
+    end.
+
+-spec maybe_change_rate(name(), pos_integer(), non_neg_integer(), throttle_info()) -> {ok, non_neg_integer()} | {error, any()}.
+maybe_change_rate(Name, Rate, Interval, Info) ->
+    CurrentRatePerMin = rate_per_minute(Info#throttle_info.rate, Info#throttle_info.interval),
+    ReqRatePerMin = rate_per_minute(Rate, Interval),
+    case {CurrentRatePerMin, Info#throttle_info.change_plan} of
+        {ReqRatePerMin, _} -> {ok, ReqRatePerMin};
+        {_, undefined} -> do_change_rate(Name, Rate, Interval);
+        _ -> {error, cannot_change_rate}
+    end.
+
+-spec do_change_rate(name(), pos_integer(), non_neg_integer()) -> {ok, non_neg_integer()} | {error, any()}.
+do_change_rate(Name, Rate, Interval) ->
+    case pg2:get_members(Name) of
+        {error, Err} -> {error, Err};
+        List when is_list(List) ->
+            RatePerMinute = rate_per_minute(Rate, Interval),
+            amoc_metrics:update_gauge(?RATE(Name), RatePerMinute),
+            update_throttle_processes(List, Interval, Rate, length(List)),
+            {ok, RatePerMinute}
+    end.
+
+-spec start_gradual_rate_change(name(), pos_integer(), pos_integer(), non_neg_integer(), pos_integer(), pos_integer(),
+                                throttle_info()) -> throttle_info().
+start_gradual_rate_change(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfSteps, Info) ->
+    {ok, LowRate} = do_change_rate(Name, LowRate, RateInterval),
+    {ok, Timer} = timer:send_interval(StepInterval, {change_plan, Name}),
+    Plan = #change_rate_plan{high_rate = HighRate, no_of_steps = NoOfSteps, timer = Timer},
+    Info#throttle_info{rate = LowRate, interval = RateInterval, change_plan = Plan}.
+
+start_throttle_processes(Name, Interval, Rate, 1) ->
+    start_throttle_process(Name, Interval, Rate);
+start_throttle_processes(Name, Interval, Rate, N) when is_integer(N), N > 1 ->
+    ProcessRate = Rate div N,
+    start_throttle_process(Name, Interval, ProcessRate),
+    start_throttle_processes(Name, Interval, Rate - ProcessRate, N - 1).
+
+start_throttle_process(Name, Interval, Rate) ->
+    {ok, Pid} = amoc_throttle_process:start(Name, Interval, Rate),
+    pg2:join(Name, Pid).
+
+update_throttle_processes([Pid], Interval, Rate, 1) ->
+    amoc_throttle_process:update(Pid, Interval, Rate);
+update_throttle_processes([Pid | Tail], Interval, Rate, N) when N > 1 ->
+    ProcessRate = Rate div N,
+    amoc_throttle_process:update(Pid, Interval, ProcessRate),
+    update_throttle_processes(Tail, Interval, Rate - ProcessRate, N - 1).
+
+all_processes(Name, Cmd) ->
+    case pg2:get_members(Name) of
+        List when is_list(List) ->
+            [run_cmd(P, Cmd) || P <- List], ok;
+        Error -> Error
+    end.
+
+run_cmd(Pid, stop) ->
+    amoc_throttle_process:stop(Pid);
+run_cmd(Pid, pause) ->
+    amoc_throttle_process:pause(Pid);
+run_cmd(Pid, resume) ->
+    amoc_throttle_process:resume(Pid).

--- a/src/amoc_throttle_controller.erl
+++ b/src/amoc_throttle_controller.erl
@@ -45,6 +45,7 @@
 -spec(start_link() ->
     {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
 start_link() ->
+    pg2:start(),
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 -spec(ensure_throttle_processes_started(name(), non_neg_integer(), non_neg_integer(), pos_integer()) ->

--- a/src/amoc_throttle_process.erl
+++ b/src/amoc_throttle_process.erl
@@ -156,7 +156,14 @@ maybe_start_timer(#state{delay_between_executions = D, tref = undefined} = State
 maybe_stop_timer(#state{tref = undefined}) ->
     ok;
 maybe_stop_timer(#state{tref = TRef}) ->
-    {ok, cancel} = timer:cancel(TRef).
+    {ok, cancel} = timer:cancel(TRef),
+    consume_all_timer_ticks(delay_between_executions).
+
+consume_all_timer_ticks(Msg) ->
+    receive
+        Msg -> consume_all_timer_ticks(Msg)
+    after 0 -> ok
+    end.
 
 maybe_run_fn(#state{schedule = [], schedule_reversed = []} = State) ->
     State;

--- a/src/amoc_throttle_process.erl
+++ b/src/amoc_throttle_process.erl
@@ -130,12 +130,13 @@ initial_state(Interval, Rate) when Rate > 0 ->
         Rate < 5 -> lager:error("too low rate, please reduce NoOfProcesses");
         true -> ok
     end,
-    Delay = case {Interval, Interval div Rate} of
-                {0, 0} -> 0; %% limit only No of simultaneous executions
-                {_, I} when I < 10 ->
+    Delay = case {Interval, Interval div Rate, Interval rem Rate} of
+                {0, _, _} -> 0; %% limit only No of simultaneous executions
+                {_, I, _} when I < 10 ->
                     lager:error("too high rate, please increase NoOfProcesses"),
                     10;
-                {_, DelayBetweenExecutions} -> DelayBetweenExecutions
+                {_, DelayBetweenExecutions, 0} -> DelayBetweenExecutions;
+                {_, DelayBetweenExecutions, _} -> DelayBetweenExecutions + 1
             end,
     #state{interval = Interval, n = Rate, max_n = Rate, delay_between_executions = Delay}.
 


### PR DESCRIPTION
ensuring that amoc throttle works correctly in distributed environment.
tested manually using `throttle_test` scenario, works correctly for both `amoc_local:do/3` and `amoc_dist:do/4`.