### PR TITLE
Settings rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ integration_test:
 	./integration_test/test_run_scenario.sh
 	./integration_test/test_add_new_node.sh
 
+rerun_integration_test:
+	./integration_test/cleanup_containers.sh
+	./integration_test/test_docker_image.sh
+	./integration_test/test_distribute_scenario.sh
+	./integration_test/test_run_scenario.sh
+	./integration_test/test_add_new_node.sh
+
 dialyzer:
 	$(REBAR) as prod dialyzer
 

--- a/integration_test/dummy_helper.erl
+++ b/integration_test/dummy_helper.erl
@@ -1,0 +1,75 @@
+-module(dummy_helper).
+
+-required_variable(#{name=>dummy_var, description=>"dummy_var",
+                     default_value=>default_value}).
+
+%% amoc_dist testing function
+-export([test_amoc_dist/0]).
+
+test_amoc_dist() ->
+    try
+        Master = amoc_cluster:master_node(),
+        Slaves = amoc_cluster:slave_nodes(),
+        %% check the status of the nodes
+        disabled = rpc:call(Master, amoc_controller, get_status, []),
+        [{running, dummy_scenario, _, _} = rpc:call(Node, amoc_controller, get_status, [])
+         || Node <- Slaves],
+        %% check user ids
+        {N1, Nodes1, Ids1, Max1} = get_users_info(Slaves),
+        true = N1 > 0,
+        N1 = Max1,
+        Ids1 = lists:seq(1, N1),
+        [AddedNode] = Slaves -- Nodes1,
+        %% add 20 users
+        {ok, _} = rpc:call(Master, amoc_dist, add, [20]),
+        timer:sleep(3000),
+        {N2, Nodes2, Ids2, Max2} = get_users_info(Slaves),
+        N2 = Max2,
+        Ids2 = lists:seq(1, N2),
+        [AddedNode] = Nodes2 -- Nodes1,
+        N2 = N1 + 20,
+        %% remove 10 users
+        {ok, _} = rpc:call(Master, amoc_dist, remove, [10, true]),
+        timer:sleep(3000),
+        {N3, Nodes3, _Ids3, Max3} = get_users_info(Slaves),
+        Nodes2 = Nodes3,
+        Max3 = Max2,
+        N2 = N3 + 10,
+        %% try to remove N3 users
+        {ok, Ret} = rpc:call(Master, amoc_dist, remove, [N3, true]),
+        RemovedN = lists:sum([N || {_, N} <- Ret]),
+        timer:sleep(3000),
+        {N4, Nodes4, Ids4, _Max4} = get_users_info(Slaves),
+        Nodes1 = Nodes4,
+        N3 = N4 + RemovedN,
+        true = RemovedN < N3,
+        %% add 20 users
+        {ok, _} = rpc:call(Master, amoc_dist, add, [20]),
+        timer:sleep(3000),
+        {N5, Nodes5, Ids5, Max5} = get_users_info(Slaves),
+        Nodes2 = Nodes5,
+        Max5 = Max2 + 20,
+        N5 = N4 + 20,
+        true = Ids5 -- Ids4 =:= lists:seq(Max2 + 1, Max5),
+        %% terminate scenario
+        {ok,_} = rpc:call(Master, amoc_dist, stop, []),
+        timer:sleep(3000),
+        [{finished, dummy_scenario} = rpc:call(Node, amoc_controller, get_status, [])
+         || Node <- Slaves],
+        %% return expected value
+        amoc_dist_works_as_expected
+    catch
+        C:E:S ->
+            {error, {C, E, S}}
+    end.
+
+get_users_info(SlaveNodes) ->
+    Users = [{Node, Id} ||
+        Node <- SlaveNodes,
+        {Id, _Pid} <- rpc:call(Node, ets, tab2list, [amoc_users])],
+    Ids = lists:usort([Id || {_, Id} <- Users]),
+    Nodes = lists:usort([Node || {Node, _} <- Users]),
+    N = length(Ids),
+    N = length(Users),
+    MaxId = lists:max(Ids),
+    {N, Nodes, Ids, MaxId}.

--- a/integration_test/dummy_scenario.erl
+++ b/integration_test/dummy_scenario.erl
@@ -1,31 +1,37 @@
 -module(dummy_scenario).
 -behaviour(amoc_scenario).
 
-%% var1 must be equal to one of the values in the list and the default value is def1
--required_variable({var1, "description1", def1, [def1, another_value]}).
+%% var1 must be equal to one of the values in the verification list
+%% and the default value is def1
+-required_variable(#{name=>var1, description=>"description1", value=>def1,
+                     verification=>[def1, another_value]}).
 
 -required_variable([
     %% var2 must be positively verified by the test_verification_function/1 function.
     %% this function must be exported from the scenario module, or from any of
-    %% the modules specified in the config_verification_modules amoc configuration
-    %% variable.
-    {var2, "description2", def2, test_verification_function},
+    %% the modules specified in the config_verification_modules erlang application
+    %% configuration variable.
+    #{name=>var2, description=> "description2", value=>def2,
+      verification=>test_verification_function},
     %% alternatively the verification function can be supplied as a function pointer
-    %% in a 'fun module:function/arity' format. Note that it must be an exported function
-    %% anyway, as 'fun function/arity' format in the module attribute simply will
+    %% in a 'fun module:function/arity' format. Note that it must be an exported function.
+    %% usage of 'fun function/arity' format in the module attribute simply will
     %% not pass compilation.
-    {var3, "description3", def3, fun ?MODULE:test_verification_function/1}]).
+    #{name=>var3,  description=>"description3", value=>def3,
+      verification=>fun ?MODULE:test_verification_function/1}]).
 
-%% none is a predefined verification function which accepts all the values
--required_variable({var4, "description4", def4, none}).
+%% 'none' is a predefined verification function which accepts all the values
+-required_variable(#{name => var4, description => "description4", value => def4,
+                     verification => none}).
 
 -required_variable([
-    %% this is the same as {var5, "description5", def5, none}
-    {var5, "description5", def5},
-    %% this is the same as {var6, "description6", undefined, none}
-    {var6, "description6"},
-    {nodes, "this variable is set for docker container via AMOC_NODES env"},
-    {test, "this one to be set via REST API"}]).
+    %% when verification method is not set, it defaults to `none`
+    #{name => var5, description => "description5", value => def5},
+    %% when value is not set, it defaults to `undefined`
+    #{name => var6, description => "description6"},
+    #{name => nodes, description => "this variable is set for docker "
+                                    "container via AMOC_NODES env"},
+    #{name => test, description => "this one to be set via REST API"}]).
 
 %% parameter verification method
 -export([test_verification_function/1]).
@@ -57,9 +63,9 @@ init() ->
     undefined = amoc_config:get(var6),
     [_ | _] = amoc_config:get(nodes),
     %% it doesn't matter if an undeclared_variable is passed through the
-    %% os/app environment variable or via JSON parameters (REST API). if
-    %% it's not declared using the -required_variable(...) attribute then
-    %% any attempt to get it results in exception.
+    %% os or erlang app environment variable. if it's not declared using
+    %% the -required_variable(...) attribute, then any attempt to get it
+    %% results in exception.
     {invalid_setting, undeclared_variable} =
         (catch amoc_config:get(undeclared_variable)),
     %% this variable is set via REST API

--- a/integration_test/dummy_scenario.erl
+++ b/integration_test/dummy_scenario.erl
@@ -3,30 +3,32 @@
 
 %% var1 must be equal to one of the values in the verification list
 %% and the default value is def1
--required_variable(#{name=>var1, description=>"description1", value=>def1,
-                     verification=>[def1, another_value]}).
+-required_variable(#{name => var1, description => "description1",
+                     default_value => def1,
+                     verification => [def1, another_value]}).
 
 -required_variable([
     %% var2 must be positively verified by the test_verification_function/1 function.
     %% this function must be exported from the scenario module, or from any of
     %% the modules specified in the config_verification_modules erlang application
     %% configuration variable.
-    #{name=>var2, description=> "description2", value=>def2,
-      verification=>test_verification_function},
+    #{name => var2, description => "description2", default_value => def2,
+      verification => test_verification_function},
     %% alternatively the verification function can be supplied as a function pointer
     %% in a 'fun module:function/arity' format. Note that it must be an exported function.
     %% usage of 'fun function/arity' format in the module attribute simply will
     %% not pass compilation.
-    #{name=>var3,  description=>"description3", value=>def3,
-      verification=>fun ?MODULE:test_verification_function/1}]).
+    #{name => var3, description => "description3", default_value => def3,
+      verification => fun ?MODULE:test_verification_function/1}]).
 
 %% 'none' is a predefined verification function which accepts all the values
--required_variable(#{name => var4, description => "description4", value => def4,
+-required_variable(#{name => var4, description => "description4",
+                     default_value => def4,
                      verification => none}).
 
 -required_variable([
     %% when verification method is not set, it defaults to `none`
-    #{name => var5, description => "description5", value => def5},
+    #{name => var5, description => "description5", default_value => def5},
     %% when value is not set, it defaults to `undefined`
     #{name => var6, description => "description6"},
     #{name => nodes, description => "this variable is set for docker "

--- a/integration_test/dummy_scenario.erl
+++ b/integration_test/dummy_scenario.erl
@@ -57,10 +57,12 @@ init() ->
     undefined = amoc_config:get(var6),
     [_ | _] = amoc_config:get(nodes),
     %% it doesn't matter if an undeclared_variable is passed through the
-    %% os or app environment variable. if it's not declared using the
-    %% -required_variable(...) it is reported as undefined variable.
-    def_value = amoc_config:get(undeclared_variable, def_value),
-    undefined = amoc_config:get(undeclared_variable),
+    %% os/app environment variable or via JSON parameters (REST API). if
+    %% it's not declared using the -required_variable(...) attribute then
+    %% any attempt to get it results in exception.
+    {invalid_setting, undeclared_variable} =
+        (catch amoc_config:get(undeclared_variable)),
+    %% this variable is set via REST API
     <<"test_value">> = amoc_config:get(test),
     ok.
 

--- a/integration_test/dummy_scenario.erl
+++ b/integration_test/dummy_scenario.erl
@@ -9,15 +9,12 @@
 
 -required_variable([
     %% var2 must be positively verified by the test_verification_function/1 function.
-    %% this function must be exported from the scenario module, or from any of
-    %% the modules specified in the config_verification_modules erlang application
-    %% configuration variable.
-    #{name => var2, description => "description2", default_value => def2,
-      verification => test_verification_function},
-    %% alternatively the verification function can be supplied as a function pointer
-    %% in a 'fun module:function/arity' format. Note that it must be an exported function.
+    %% verification function must be supplied as a function pointer in a
+    %% 'fun module:function/arity' format. Note that it must be an exported function.
     %% usage of 'fun function/arity' format in the module attribute simply will
     %% not pass compilation.
+    #{name => var2, description => "description2", default_value => def2,
+      verification => fun ?MODULE:test_verification_function/1},
     #{name => var3, description => "description3", default_value => def3,
       verification => fun ?MODULE:test_verification_function/1}]).
 

--- a/integration_test/dummy_scenario.erl
+++ b/integration_test/dummy_scenario.erl
@@ -38,9 +38,6 @@
 %% amoc_scenario behaviour
 -export([init/0, start/1]).
 
-%% amoc_dist testing function
--export([test_amoc_dist/0]).
-
 test_verification_function(def2) -> true;
 test_verification_function(_)    -> {true, new_value}.
 
@@ -69,6 +66,9 @@ init() ->
         (catch amoc_config:get(undeclared_variable)),
     %% this variable is set via REST API
     <<"test_value">> = amoc_config:get(test),
+    %% dummy_var variable is defined in the dummy_helper module.
+    %% if dummy_helper is not propagated, then this call crashes
+    default_value = amoc_config:get(dummy_var),
     ok.
 
 -spec start(amoc_scenario:user_id()) -> any().
@@ -76,72 +76,3 @@ start(_Id) ->
     %%sleep 15 minutes
     timer:sleep(1000 * 60 * 15),
     amoc_user:stop().
-
-
-test_amoc_dist() ->
-    try
-        Master = amoc_cluster:master_node(),
-        Slaves = amoc_cluster:slave_nodes(),
-        %% check the status of the nodes
-        disabled = rpc:call(Master, amoc_controller, get_status, []),
-        [{running, ?MODULE, _, _} = rpc:call(Node, amoc_controller, get_status, []) ||
-            Node <- Slaves],
-        %% check user ids
-        {N1, Nodes1, Ids1, Max1} = get_users_info(Slaves),
-        true = N1 > 0,
-        N1 = Max1,
-        Ids1 = lists:seq(1, N1),
-        [AddedNode] = Slaves -- Nodes1,
-        %% add 20 users
-        {ok, _} = rpc:call(Master, amoc_dist, add, [20]),
-        timer:sleep(3000),
-        {N2, Nodes2, Ids2, Max2} = get_users_info(Slaves),
-        N2 = Max2,
-        Ids2 = lists:seq(1, N2),
-        [AddedNode] = Nodes2 -- Nodes1,
-        N2 = N1 + 20,
-        %% remove 10 users
-        {ok, _} = rpc:call(Master, amoc_dist, remove, [10, true]),
-        timer:sleep(3000),
-        {N3, Nodes3, _Ids3, Max3} = get_users_info(Slaves),
-        Nodes2 = Nodes3,
-        Max3 = Max2,
-        N2 = N3 + 10,
-        %% try to remove N3 users
-        {ok, Ret} = rpc:call(Master, amoc_dist, remove, [N3, true]),
-        RemovedN = lists:sum([N || {_, N} <- Ret]),
-        timer:sleep(3000),
-        {N4, Nodes4, Ids4, _Max4} = get_users_info(Slaves),
-        Nodes1 = Nodes4,
-        N3 = N4 + RemovedN,
-        true = RemovedN < N3,
-        %% add 20 users
-        {ok, _} = rpc:call(Master, amoc_dist, add, [20]),
-        timer:sleep(3000),
-        {N5, Nodes5, Ids5, Max5} = get_users_info(Slaves),
-        Nodes2 = Nodes5,
-        Max5 = Max2 + 20,
-        N5 = N4 + 20,
-        true = Ids5 -- Ids4 =:= lists:seq(Max2 + 1, Max5),
-        %% terminate scenario
-        {ok,_} = rpc:call(Master, amoc_dist, stop, []),
-        timer:sleep(3000),
-        [{finished, ?MODULE} = rpc:call(Node, amoc_controller, get_status, []) ||
-            Node <- Slaves],
-        %% return expected value
-        amoc_dist_works_as_expected
-    catch
-        C:E:S ->
-            {error, {C, E, S}}
-    end.
-
-get_users_info(SlaveNodes) ->
-    Users = [{Node, Id} ||
-                Node <- SlaveNodes,
-                {Id, _Pid} <- rpc:call(Node, ets, tab2list, [amoc_users])],
-    Ids = lists:usort([Id || {_, Id} <- Users]),
-    Nodes = lists:usort([Node || {Node, _} <- Users]),
-    N = length(Ids),
-    N = length(Users),
-    MaxId = lists:max(Ids),
-    {N, Nodes, Ids, MaxId}.

--- a/integration_test/test_add_new_node.sh
+++ b/integration_test/test_add_new_node.sh
@@ -23,7 +23,7 @@ docker run --rm -t -d --name amoc-4 -h amoc-4 \
 
 docker exec -it amoc-4 ${PATH_TO_EXEC} eval "amoc_controller:get_status()" | grep dummy_scenario | grep running
 docker exec -it amoc-4 ${PATH_TO_EXEC} eval "amoc_config:get(test)" | grep '<<"test_value">>'
-docker exec -it amoc-4 ${PATH_TO_EXEC} eval "dummy_scenario:test_amoc_dist()" | tee /dev/tty | grep -q 'amoc_dist_works_as_expected'
+docker exec -it amoc-4 ${PATH_TO_EXEC} eval "dummy_helper:test_amoc_dist()" | tee /dev/tty | grep -q 'amoc_dist_works_as_expected'
 
 
 

--- a/integration_test/test_distribute_scenario.sh
+++ b/integration_test/test_distribute_scenario.sh
@@ -52,10 +52,15 @@ list_scenarios_by_port ${PORT3}
 
 echo "Installing scenario: 'dummy_scenario.erl' on node amoc-1 (port ${PORT1})"
 
-SCEN_PUT=$(curl -s -H "Content-Type: text/plain" \
+SCENARIO_PUT=$(curl -s -H "Content-Type: text/plain" \
                  -T integration_test/dummy_scenario.erl \
                  'http://localhost:8081/scenarios/upload')
-echo "Response: ${SCEN_PUT}"
+echo "Response: ${SCENARIO_PUT}"
+
+HELPER_PUT=$(curl -s -H "Content-Type: text/plain" \
+                 -T integration_test/dummy_helper.erl \
+                 'http://localhost:8081/scenarios/upload')
+echo "Response: ${HELPER_PUT}"
 
 ensure_scenarios_installed ${PORT2} ${SCENARIO_NAME}
 ensure_scenarios_installed ${PORT3} ${SCENARIO_NAME}

--- a/src/amoc.erl
+++ b/src/amoc.erl
@@ -16,7 +16,7 @@
 %% API for the local scenario execution, use amoc_dist module to run
 %% scenarios in a distributed environment
 %% ------------------------------------------------------------------
--spec do(scenario(), non_neg_integer(), amoc_config_scenario:config()) ->
+-spec do(scenario(), non_neg_integer(), amoc_config:settings()) ->
     ok | {error, term()}.
 do(Scenario, Count, Settings) ->
     case amoc_cluster:set_master_node(node()) of

--- a/src/amoc_config/amoc_config.erl
+++ b/src/amoc_config/amoc_config.erl
@@ -4,14 +4,11 @@
 %%==============================================================================
 -module(amoc_config).
 
--export([get/1, get/2]).
-
--export_type([name/0, value/0]).
-
--type name() :: atom().
--type value() :: any().
-
 -include_lib("kernel/include/logger.hrl").
+-include("amoc_config.hrl").
+
+-export([get/1, get/2]).
+-export_type([name/0, value/0, settings/0]).
 
 %% ------------------------------------------------------------------
 %% API
@@ -25,10 +22,10 @@ get(Name, Default) when is_atom(Name) ->
     case ets:lookup(amoc_config, Name) of
         [] ->
             ?LOG_ERROR("no scenario setting ~p", [Name]),
+            throw({invalid_setting, Name});
+        [{Name, _Module, undefined, _VerifyFn}] ->
             Default;
-        [{Name, undefined}] ->
-            Default;
-        [{Name, Value}] ->
+        [{Name, _Module, Value, _VerifyFn}] ->
             Value;
         InvalidLookupRet ->
             ?LOG_ERROR("invalid lookup return value ~p ~p", [Name, InvalidLookupRet]),

--- a/src/amoc_config/amoc_config.erl
+++ b/src/amoc_config/amoc_config.erl
@@ -23,9 +23,9 @@ get(Name, Default) when is_atom(Name) ->
         [] ->
             ?LOG_ERROR("no scenario setting ~p", [Name]),
             throw({invalid_setting, Name});
-        [{Name, _Module, undefined, _VerifyFn, _UpdateFn}] ->
+        [#module_parameter{name = Name, value = undefined}] ->
             Default;
-        [{Name, _Module, Value, _VerifyFn, _UpdateFn}] ->
+        [#module_parameter{name = Name, value = Value}] ->
             Value;
         InvalidLookupRet ->
             ?LOG_ERROR("invalid lookup return value ~p ~p", [Name, InvalidLookupRet]),

--- a/src/amoc_config/amoc_config.erl
+++ b/src/amoc_config/amoc_config.erl
@@ -23,9 +23,9 @@ get(Name, Default) when is_atom(Name) ->
         [] ->
             ?LOG_ERROR("no scenario setting ~p", [Name]),
             throw({invalid_setting, Name});
-        [{Name, _Module, undefined, _VerifyFn}] ->
+        [{Name, _Module, undefined, _VerifyFn, _UpdateFn}] ->
             Default;
-        [{Name, _Module, Value, _VerifyFn}] ->
+        [{Name, _Module, Value, _VerifyFn, _UpdateFn}] ->
             Value;
         InvalidLookupRet ->
             ?LOG_ERROR("invalid lookup return value ~p ~p", [Name, InvalidLookupRet]),

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -30,20 +30,25 @@
                                                       {true, NewValue :: value()} |
                                                       {false, reason()}).
 
+-type update_fun() :: fun((ParamName :: name(), NewValue :: value()) -> any()).
+
 -type module_parameter() :: {ParamName :: name(), module(), DefValue :: value(),
-                             verification_fun()}.
+                             verification_fun(), update_fun() | read_only}.
 
 -type module_configuration() :: [module_parameter()].
 
 -type one_of() :: [value(), ...].
 -type fn_name() :: atom().
 -type verification_method() :: none | one_of() | fn_name() | verification_fun().
+-type update_method() :: read_only | none | fn_name() | update_fun().
 
 -type module_attribute() ::
     {ParamName :: name(), Description :: string()} |
     {ParamName :: name(), Description :: string(), DefValue :: value()} |
     {ParamName :: name(), Description :: string(), DefValue :: value(),
-                          verification_method()}.
+                          verification_method()} |
+    {ParamName :: name(), Description :: string(), DefValue :: value(),
+                          verification_method(), update_method()}.
 
 
 

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -13,8 +13,7 @@
 %%------------------------------------------------------------------------------
 %% runtime supplied settings
 %%------------------------------------------------------------------------------
--type parameter() :: {name(), value()}.
--type settings() :: [parameter()].
+-type settings() :: [{name(), value()}].
 
 %%------------------------------------------------------------------------------
 %% error types
@@ -33,7 +32,7 @@
 -type update_fun() :: fun((ParamName :: name(), NewValue :: value()) -> any()).
 
 -type maybe_verification_fun() :: verification_fun() | fun((_)-> any()).
--type maybe_update_fun() :: verification_fun() | fun((_,_)-> any()).
+-type maybe_update_fun() :: update_fun() | fun((_,_)-> any()).
 
 -record(module_parameter, {name :: name(),
                            mod :: module(),
@@ -51,10 +50,6 @@
 
 -type module_attribute() :: #{ name := name(),
                                description := string(),
-                               value => value(),
+                               default_value => value(),
                                verification => verification_method(),
                                update => update_method()}.
-
-
-
-

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -1,0 +1,50 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+
+
+%%------------------------------------------------------------------------------
+%% basic types
+%%------------------------------------------------------------------------------
+-type name() :: atom().
+-type value() :: any().
+
+%%------------------------------------------------------------------------------
+%% runtime supplied settings
+%%------------------------------------------------------------------------------
+-type parameter() :: {name(), value()}.
+-type settings() :: [parameter()].
+
+%%------------------------------------------------------------------------------
+%% error types
+%%------------------------------------------------------------------------------
+-type reason() :: any().
+-type error_type() :: atom().
+-type error() :: {error, error_type(), reason()}.
+
+%%------------------------------------------------------------------------------
+%% module attributes definition
+%%------------------------------------------------------------------------------
+-type verification_fun() :: fun((Value :: value()) -> boolean() |
+                                                      {true, NewValue :: value()} |
+                                                      {false, reason()}).
+
+-type module_parameter() :: {ParamName :: name(), module(), DefValue :: value(),
+                             verification_fun()}.
+
+-type module_configuration() :: [module_parameter()].
+
+-type one_of() :: [value(), ...].
+-type fn_name() :: atom().
+-type verification_method() :: none | one_of() | fn_name() | verification_fun().
+
+-type module_attribute() ::
+    {ParamName :: name(), Description :: string()} |
+    {ParamName :: name(), Description :: string(), DefValue :: value()} |
+    {ParamName :: name(), Description :: string(), DefValue :: value(),
+                          verification_method()}.
+
+
+
+

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -49,13 +49,11 @@
 -type verification_method() :: none | one_of() | fn_name() | verification_fun().
 -type update_method() :: read_only | none | fn_name() | update_fun().
 
--type module_attribute() ::
-    {ParamName :: name(), Description :: string()} |
-    {ParamName :: name(), Description :: string(), DefValue :: value()} |
-    {ParamName :: name(), Description :: string(), DefValue :: value(),
-                          verification_method()} |
-    {ParamName :: name(), Description :: string(), DefValue :: value(),
-                          verification_method(), update_method()}.
+-type module_attribute() :: #{ name := name(),
+                               description := string(),
+                               value => value(),
+                               verification => verification_method(),
+                               update => update_method()}.
 
 
 

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -44,9 +44,8 @@
 -type module_configuration() :: [module_parameter()].
 
 -type one_of() :: [value(), ...].
--type fn_name() :: atom().
--type verification_method() :: none | one_of() | fn_name() | verification_fun().
--type update_method() :: read_only | none | fn_name() | update_fun().
+-type verification_method() :: none | one_of() | verification_fun().
+-type update_method() :: read_only | none | update_fun().
 
 -type module_attribute() :: #{ name := name(),
                                description := string(),

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -32,9 +32,16 @@
 
 -type update_fun() :: fun((ParamName :: name(), NewValue :: value()) -> any()).
 
--type module_parameter() :: {ParamName :: name(), module(), DefValue :: value(),
-                             verification_fun(), update_fun() | read_only}.
+-type maybe_verification_fun() :: verification_fun() | fun((_)-> any()).
+-type maybe_update_fun() :: verification_fun() | fun((_,_)-> any()).
 
+-record(module_parameter, {name :: name(),
+                           mod :: module(),
+                           value :: value(),
+                           verification_fn :: maybe_verification_fun(),
+                           update_fn = read_only :: maybe_update_fun() | read_only}).
+
+-type module_parameter() :: #module_parameter{}.
 -type module_configuration() :: [module_parameter()].
 
 -type one_of() :: [value(), ...].

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -68,7 +68,7 @@ process_var_attr(Module, Attr) ->
     end.
 
 -spec check_mandatory_fields(maybe_module_attribute()) ->
-    {ok, maybe_module_attribute()} | {error, reason()}.
+    {ok, #{name := name(), description := string(), any() => any()}} | {error, reason()}.
 check_mandatory_fields(#{description := List, name := Atom} = Attr) when is_atom(Atom),
                                                                          is_list(List) ->
     case io_lib:char_list(List) of
@@ -78,13 +78,14 @@ check_mandatory_fields(#{description := List, name := Atom} = Attr) when is_atom
 check_mandatory_fields(_Attr) ->
     {error, invalid_attribute}.
 
--spec check_default_value(maybe_module_attribute()) -> {ok, maybe_module_attribute()}.
+-spec check_default_value(#{any() => any()}) ->
+    {ok, #{default_value := value(), any() => any()}}.
 check_default_value(Attr) ->
     DefaultValue = maps:get(default_value, Attr, undefined),
     {ok, Attr#{default_value => DefaultValue}}.
 
--spec check_verification_method(maybe_module_attribute()) ->
-    {ok, maybe_module_attribute()} | {error, reason()}.
+-spec check_verification_method(#{any() => any()}) ->
+    {ok, #{verification := maybe_verification_fun(), any() => any()}} | {error, reason()}.
 check_verification_method(Attr) ->
     VerificationMethod = maps:get(verification, Attr, none),
     case verification_fn(VerificationMethod) of
@@ -96,8 +97,8 @@ check_verification_method(Attr) ->
             {ok, Attr#{verification => VerificationFn}}
     end.
 
--spec check_update_method(maybe_module_attribute()) ->
-    {ok, maybe_module_attribute()} | {error, reason()}.
+-spec check_update_method(#{any() => any()}) ->
+    {ok, #{update := maybe_update_fun(), any() => any()}} | {error, reason()}.
 check_update_method(Attr) ->
     UpdateMethod = maps:get(update, Attr, read_only),
     case update_fn(UpdateMethod) of
@@ -109,7 +110,12 @@ check_update_method(Attr) ->
             {ok, Attr#{update => UpdateFn}}
     end.
 
--spec make_module_parameter(module_attribute(), module()) ->
+-spec make_module_parameter(#{name := name(),
+                              default_value := value(),
+                              verification := maybe_verification_fun(),
+                              update := maybe_update_fun(),
+                              any() => any()},
+                            module()) ->
     {ok, module_parameter()}.
 make_module_parameter(#{name := Name, default_value := Value, update := UpdateFn,
                         verification := VerificationFn}, Module) ->

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -29,12 +29,8 @@
 -spec get_module_configuration(attribute_name(), module()) ->
     {ok, module_configuration()} | amoc_config_utils:error().
 get_module_configuration(AttrName, Module) ->
-    try
-        ScenarioAttributes = get_module_attributes(AttrName, Module),
-        process_module_attributes(Module, ScenarioAttributes)
-    catch
-        _:_ -> {error, invalid_module, Module}
-    end.
+    ScenarioAttributes = get_module_attributes(AttrName, Module),
+    process_module_attributes(Module, ScenarioAttributes).
 
 -spec none(any()) -> true.
 none(_) -> true.

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -1,0 +1,115 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+%% this module is responsible for parsing module attributes
+%%==============================================================================
+-module(amoc_config_attributes).
+
+-include("amoc_config.hrl").
+
+%% API
+-export([get_module_configuration/3]).
+-ifdef(TEST).
+-export([%% exported for testing only
+         get_module_attributes/2,
+         process_module_attributes/3]).
+-endif.
+
+-type maybe_module_attribute() :: module_attribute() | term().
+
+-type maybe_verification_method() :: verification_method() | term().
+-type raw_module_parameter() ::
+    {amoc_config:name(), module(), amoc_config:value(), maybe_verification_method()}.
+
+-type attribute_name() :: required_variable | override_variable.
+
+%% ------------------------------------------------------------------
+%% API
+%% ------------------------------------------------------------------
+-spec get_module_configuration(attribute_name(), module(), [module()]) ->
+    {ok, module_configuration()} | amoc_config_utils:error().
+get_module_configuration(AttrName, Module, VerificationModules) ->
+    try
+        ScenarioAttributes = get_module_attributes(AttrName, Module),
+        AllVerificationModules = [Module | VerificationModules],
+        process_module_attributes(AllVerificationModules, Module, ScenarioAttributes)
+    catch
+        _:_ -> {error, invalid_module, Module}
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+-spec get_module_attributes(attribute_name(), module()) -> [maybe_module_attribute()].
+get_module_attributes(AttrName, Module) ->
+    ModuleAttributes = apply(Module, module_info, [attributes]),
+    RequiredVariables = proplists:get_all_values(AttrName, ModuleAttributes),
+    lists:append(RequiredVariables).
+
+-spec process_module_attributes([module()], module(), [maybe_module_attribute()]) ->
+    {ok, module_configuration()} | amoc_config_utils:error().
+process_module_attributes(VerificationModules, Module, ScenarioAttributes) ->
+    Config = [process_var_attr(VerificationModules, Module, Attr)
+              || Attr <- ScenarioAttributes],
+    amoc_config_utils:maybe_error(invalid_attribute_format, Config).
+
+-spec process_var_attr([module()], module(), maybe_module_attribute()) ->
+    {ok, module_parameter()} | {error, reason()}.
+process_var_attr(_, Module, Attr) when not is_atom(element(1, Attr));
+                                       not is_list(element(2, Attr)) ->
+    {error, {invalid_attribute, Attr}};
+process_var_attr(_, Module, {Name, _}) ->
+    {ok, {Name, Module, undefined, fun none/1}};
+process_var_attr(_, Module, {Name, _, DefaultValue}) ->
+    {ok, {Name, Module, DefaultValue, fun none/1}};
+process_var_attr(VerificationModules, Module, {Name, _, DefaultValue,
+                                               VerificationMethod}) ->
+    Parameter = {Name, Module, DefaultValue, VerificationMethod},
+    check_verification_method(VerificationModules, Parameter);
+process_var_attr(_, _, InvalidAttribute) ->
+    {error, {invalid_attribute, InvalidAttribute}}.
+
+-spec check_verification_method([module()], raw_module_parameter()) ->
+    {ok, module_parameter()} | {error, reason()}.
+check_verification_method(Modules, {Name, Module, DefaultValue,
+                                    VerificationMethod} = Param) ->
+    case verification_fun(Modules, VerificationMethod) of
+        not_exported -> {error, {verification_method_not_exported, Param, Modules}};
+        invalid_method -> {error, {invalid_verification_method, Param}};
+        VerificationFn -> {ok, {Name, Module, DefaultValue, VerificationFn}}
+    end.
+
+-spec verification_fun([module()], maybe_verification_method()) ->
+    verification_fun() | not_exported | invalid_method.
+verification_fun(_, none) ->
+    fun none/1;
+verification_fun(_, [_ | _] = OneOF) ->
+    one_of_fun(OneOF);
+verification_fun(_, Fun) when is_function(Fun, 1) ->
+    Fun;
+verification_fun(Modules, Atom) when is_atom(Atom) ->
+    is_exported(Modules, Atom, 1);
+verification_fun(_, _) ->
+    invalid_method.
+
+-spec is_exported([module()], atom(), non_neg_integer()) ->
+    function() | not_exported.
+is_exported([], _, _) ->
+    not_exported;
+is_exported([Module | T], Function, Arity) ->
+    case erlang:function_exported(Module, Function, Arity) of
+        true -> fun Module:Function/Arity;
+        false -> is_exported(T, Function, Arity)
+    end.
+
+none(_) -> true.
+
+-spec one_of_fun(one_of()) -> verification_fun().
+one_of_fun(OneOf) ->
+    fun(X) ->
+        case lists:member(X, OneOf) of
+            true -> true;
+            false -> {false, {not_one_of, OneOf}}
+        end
+    end.

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -10,6 +10,7 @@
 
 %% API
 -export([get_module_configuration/3]).
+-export([none/1, none/2]).
 -ifdef(TEST).
 -export([%% exported for testing only
          get_module_attributes/2,
@@ -35,6 +36,11 @@ get_module_configuration(AttrName, Module, VerificationModules) ->
         _:_ -> {error, invalid_module, Module}
     end.
 
+-spec none(any()) -> true.
+none(_) -> true.
+
+-spec none(any(), any()) -> ok.
+none(_, _) -> ok.
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
@@ -54,15 +60,16 @@ process_module_attributes(VerificationModules, Module, ScenarioAttributes) ->
 -spec process_var_attr([module()], module(), maybe_module_attribute()) ->
     {ok, module_parameter()} | {error, reason()}.
 process_var_attr(VerificationModules, Module, Attr) ->
-    AllVerificationModules = [Module | VerificationModules],
     PipelineActions = [
         {fun check_mandatory_fields/1, []},
         {fun check_default_value/1, []},
-        {fun check_verification_method/3, [AllVerificationModules,Attr]},
-        {fun check_update_method/3, [AllVerificationModules,Attr]},
+        {fun check_verification_method/4, [VerificationModules, Module, Attr]},
+        {fun check_update_method/4, [VerificationModules, Module, Attr]},
         {fun make_module_parameter/2, [Module]}],
     amoc_config_utils:pipeline(PipelineActions, {ok, Attr}).
 
+-spec check_mandatory_fields(maybe_module_attribute()) ->
+    {ok, maybe_module_attribute()} | {error, reason()}.
 check_mandatory_fields(#{description := List, name := Atom} = Attr) when is_atom(Atom),
                                                                          is_list(List) ->
     case io_lib:char_list(List) of
@@ -72,80 +79,127 @@ check_mandatory_fields(#{description := List, name := Atom} = Attr) when is_atom
 check_mandatory_fields(Attr) ->
     {error, {invalid_attribute, Attr}}.
 
+-spec check_default_value(maybe_module_attribute()) -> {ok, maybe_module_attribute()}.
 check_default_value(Attr) ->
     DefaultValue = maps:get(value, Attr, undefined),
     {ok, Attr#{value => DefaultValue}}.
 
-check_verification_method(Attr, VerificationModules, OriginalAttr) ->
+-spec check_verification_method(maybe_module_attribute(), [module()],
+                                module(), maybe_module_attribute()) ->
+    {ok, maybe_module_attribute()} | {error, reason()}.
+check_verification_method(Attr, VerificationModules, Module, OriginalAttr) ->
     VerificationMethod = maps:get(verification, Attr, none),
-    case verification_fn(VerificationModules, VerificationMethod) of
+    case verification_fn(VerificationModules, Module, VerificationMethod) of
         not_exported ->
             {error, {verification_method_not_exported, OriginalAttr,
-                     VerificationModules}};
+                     [Module | VerificationModules]}};
         invalid_method ->
             {error, {invalid_verification_method, OriginalAttr}};
+        {multiple_functions_found, Functions} ->
+            {error, {multiple_functions_found, Functions, OriginalAttr}};
         VerificationFn ->
             {ok, Attr#{verification => VerificationFn}}
     end.
 
-check_update_method(Attr, VerificationModules, OriginalAttr) ->
+-spec check_update_method(maybe_module_attribute(), [module()],
+                          module(), maybe_module_attribute()) ->
+    {ok, maybe_module_attribute()} | {error, reason()}.
+check_update_method(Attr, VerificationModules, Module, OriginalAttr) ->
     UpdateMethod = maps:get(update, Attr, read_only),
-    case update_fn(VerificationModules, UpdateMethod) of
+    case update_fn(VerificationModules, Module, UpdateMethod) of
         not_exported ->
             {error, {update_method_not_exported, OriginalAttr,
-                     VerificationModules}};
+                     [Module | VerificationModules]}};
         invalid_method ->
             {error, {invalid_update_method, OriginalAttr}};
+        {multiple_functions_found, Functions} ->
+            {error, {multiple_functions_found, Functions, OriginalAttr}};
         UpdateFn ->
-            {ok, Attr#{update=>UpdateFn}}
+            {ok, Attr#{update => UpdateFn}}
     end.
 
+-spec make_module_parameter(maybe_module_attribute(), module()) ->
+    {ok, module_parameter()}.
 make_module_parameter(#{name := Name, value := Value, update := UpdateFn,
                         verification := VerificationFn}, Module) ->
     {ok, #module_parameter{name = Name, mod = Module, value = Value,
-                           verification_fn = VerificationFn,update_fn = UpdateFn}}.
+                           verification_fn = VerificationFn, update_fn = UpdateFn}}.
 
--spec verification_fn([module()], maybe_verification_method()) ->
-    maybe_verification_fun() | not_exported | invalid_method.
-verification_fn(_, none) ->
-    fun none/1;
-verification_fn(_, [_ | _] = OneOF) ->
+-spec verification_fn([module()], module(), maybe_verification_method()) ->
+    maybe_verification_fun() | not_exported | invalid_method
+    | {multiple_functions_found, [maybe_verification_fun()]}.
+verification_fn(_, _, none) ->
+    fun ?MODULE:none/1;
+verification_fn(_, _, [_ | _] = OneOF) ->
     one_of_fun(OneOF);
-verification_fn(_, Fun) when is_function(Fun, 1) ->
+verification_fn(_, _, Fun) when is_function(Fun, 1) ->
     Fun;
-verification_fn(Modules, Atom) when is_atom(Atom) ->
-    is_exported(Modules, Atom, 1);
-verification_fn(_, _) ->
+verification_fn(VerificationModules, Module, Atom) when is_atom(Atom) ->
+    select_function(VerificationModules, Module, Atom, 1);
+verification_fn(_, _, _) ->
     invalid_method.
 
--spec update_fn([module()], maybe_update_method()) ->
-    maybe_update_fun() | not_exported | invalid_method | read_only.
-update_fn(_, read_only) ->
+-spec update_fn([module()], module(), maybe_update_method()) ->
+    maybe_update_fun() | not_exported | invalid_method
+    | read_only | {multiple_functions_found, [maybe_update_fun()]}.
+update_fn(_, _, read_only) ->
     read_only;
-update_fn(_, none) ->
-    fun none/2;
-update_fn(_, Fun) when is_function(Fun, 2) ->
+update_fn(_, _, none) ->
+    fun ?MODULE:none/2;
+update_fn(_, _, Fun) when is_function(Fun, 2) ->
     Fun;
-update_fn(Modules, Atom) when is_atom(Atom) ->
-    is_exported(Modules, Atom, 2);
-update_fn(_, _) ->
+update_fn(VerificationModules, Module, Atom) when is_atom(Atom) ->
+    select_function(VerificationModules, Module, Atom, 2);
+update_fn(_, _, _) ->
     invalid_method.
 
--spec is_exported([module()], atom(), non_neg_integer()) ->
-    function() | not_exported.
-is_exported([], _, _) ->
+-spec select_function([module()], module(), atom(), non_neg_integer()) ->
+    function() | not_exported | {multiple_functions_found, [function()]}.
+select_function(VerificationModules, Module, FunctionName, Arity) ->
+    %% first try to find exported function in the current module, then
+    %% check config_verification_modules defined for the application of
+    %% the current module, then try config_verification_modules defined
+    %% in all other applications.
+    AppVerificationModules = get_app_verification_modules(Module),
+    OtherVerificationModules = VerificationModules -- AppVerificationModules,
+    ModuleSets = [[Module], AppVerificationModules, OtherVerificationModules],
+    select_function(ModuleSets, FunctionName, Arity).
+
+-spec select_function([[module()]], atom(), non_neg_integer()) ->
+    function() | not_exported | {multiple_functions_found, [function()]}.
+select_function([], _FunctionName, _Arity) ->
     not_exported;
-is_exported([Module | T], Function, Arity) ->
-    case erlang:function_exported(Module, Function, Arity) of
-        true -> fun Module:Function/Arity;
-        false -> is_exported(T, Function, Arity)
+select_function([Modules | T], FunctionName, Arity) ->
+    case is_exported(Modules, [], FunctionName, Arity) of
+        not_exported -> select_function(T, FunctionName, Arity);
+        ReturnValue -> ReturnValue
     end.
 
-none(_) -> true.
+-spec get_app_verification_modules(module()) -> [module()].
+get_app_verification_modules(Module) ->
+    case application:get_application(Module) of
+        undefined -> [];
+        {ok, App} ->
+            Modules = application:get_env(App, config_verification_modules, []),
+            lists:usort(Modules)
+    end.
 
-
-
-none(_, _) -> ok.
+-spec is_exported([module()],[function()], atom(), non_neg_integer()) ->
+    function() | not_exported | {multiple_functions_found, [function()]}.
+is_exported([],[], _, _) ->
+    not_exported;
+is_exported([],[FN], _, _) ->
+    FN;
+is_exported([],Functions, _, _)when length(Functions)>1 ->
+    {multiple_functions_found, Functions};
+is_exported([Module | T], Functions, FunctionName, Arity) ->
+    case erlang:function_exported(Module, FunctionName, Arity) of
+        true ->
+            FN=fun Module:FunctionName/Arity,
+            is_exported(T,[FN|Functions],FunctionName, Arity);
+        false ->
+            is_exported(T, Functions, FunctionName, Arity)
+    end.
 
 -spec one_of_fun(one_of()) -> verification_fun().
 one_of_fun(OneOf) ->

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -61,7 +61,6 @@ process_module_attributes(VerificationModules, Module, ScenarioAttributes) ->
     {ok, module_parameter()} | {error, reason()}.
 process_var_attr(VerificationModules, Module, Attr) ->
     PipelineActions = [
-        {fun maybe_convert_old_attribute_format/1, []},
         {fun check_mandatory_fields/1, []},
         {fun check_default_value/1, []},
         {fun check_verification_method/3, [VerificationModules, Module]},
@@ -71,20 +70,6 @@ process_var_attr(VerificationModules, Module, Attr) ->
         {error, Reason} -> {error, add_original_attribute(Reason, Attr)};
         {ok, Param} -> {ok, Param}
     end.
-
--spec maybe_convert_old_attribute_format(maybe_module_attribute()) ->
-    {ok, maybe_module_attribute()}.
-maybe_convert_old_attribute_format({Name, Description}) ->
-    {ok, #{name => Name, description => maybe_convert_description(Description)}};
-maybe_convert_old_attribute_format({Name, Description, DefaultValue}) ->
-    {ok, #{name => Name, description => maybe_convert_description(Description),
-           default_value => DefaultValue}};
-maybe_convert_old_attribute_format({Name, Description, DefaultValue,
-                                    VerificationMethod}) ->
-    {ok, #{name => Name, description => maybe_convert_description(Description),
-           default_value => DefaultValue, verification => VerificationMethod}};
-maybe_convert_old_attribute_format(Attr) ->
-    {ok, Attr}.
 
 -spec check_mandatory_fields(maybe_module_attribute()) ->
     {ok, maybe_module_attribute()} | {error, reason()}.
@@ -229,8 +214,3 @@ add_original_attribute(Reason, Attr) when is_tuple(Reason) ->
     list_to_tuple([Attr | tuple_to_list(Reason)]);
 add_original_attribute(Reason, Attr) ->
     {Attr, Reason}.
-
-maybe_convert_description(Binary) when is_binary(Binary) ->
-    binary_to_list(Binary);
-maybe_convert_description(Description) ->
-    Description.

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -109,7 +109,7 @@ check_update_method(Attr) ->
             {ok, Attr#{update => UpdateFn}}
     end.
 
--spec make_module_parameter(maybe_module_attribute(), module()) ->
+-spec make_module_parameter(module_attribute(), module()) ->
     {ok, module_parameter()}.
 make_module_parameter(#{name := Name, default_value := Value, update := UpdateFn,
                         verification := VerificationFn}, Module) ->

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -19,8 +19,10 @@
 -type maybe_module_attribute() :: module_attribute() | term().
 
 -type maybe_verification_method() :: verification_method() | term().
+-type maybe_update_method() :: update_method() | term().
 -type raw_module_parameter() ::
-    {amoc_config:name(), module(), amoc_config:value(), maybe_verification_method()}.
+    {amoc_config:name(), module(), amoc_config:value(),
+     maybe_verification_method(), maybe_update_method()}.
 
 -type attribute_name() :: required_variable | override_variable.
 
@@ -60,24 +62,49 @@ process_var_attr(_, Module, Attr) when not is_atom(element(1, Attr));
                                        not is_list(element(2, Attr)) ->
     {error, {invalid_attribute, Attr}};
 process_var_attr(_, Module, {Name, _}) ->
-    {ok, {Name, Module, undefined, fun none/1}};
+    {ok, {Name, Module, undefined, fun none/1, read_only}};
 process_var_attr(_, Module, {Name, _, DefaultValue}) ->
-    {ok, {Name, Module, DefaultValue, fun none/1}};
+    {ok, {Name, Module, DefaultValue, fun none/1, read_only}};
 process_var_attr(VerificationModules, Module, {Name, _, DefaultValue,
                                                VerificationMethod}) ->
-    Parameter = {Name, Module, DefaultValue, VerificationMethod},
+    Parameter = {Name, Module, DefaultValue, VerificationMethod, read_only},
     check_verification_method(VerificationModules, Parameter);
+process_var_attr(VerificationModules, Module, {Name, _, DefaultValue,
+                                               VerificationMethod,
+                                               UpdateMethod}) ->
+    Parameter = {Name, Module, DefaultValue, VerificationMethod, UpdateMethod},
+    check_verification_and_update_method(VerificationModules, Parameter);
 process_var_attr(_, _, InvalidAttribute) ->
     {error, {invalid_attribute, InvalidAttribute}}.
 
--spec check_verification_method([module()], raw_module_parameter()) ->
+-spec check_verification_and_update_method([module()], raw_module_parameter()) ->
     {ok, module_parameter()} | {error, reason()}.
+check_verification_and_update_method(Modules, Param) ->
+    case check_verification_method(Modules, Param) of
+        {ok, Param2} -> check_update_method(Modules, Param2);
+        Error -> Error
+    end.
+
+-spec check_verification_method([module()], raw_module_parameter()) ->
+    {ok, raw_module_parameter()} | {error, reason()}.
 check_verification_method(Modules, {Name, Module, DefaultValue,
-                                    VerificationMethod} = Param) ->
+                                    VerificationMethod,
+                                    UpdateMethod} = Param) ->
     case verification_fun(Modules, VerificationMethod) of
         not_exported -> {error, {verification_method_not_exported, Param, Modules}};
         invalid_method -> {error, {invalid_verification_method, Param}};
-        VerificationFn -> {ok, {Name, Module, DefaultValue, VerificationFn}}
+        VerificationFn -> {ok, {Name, Module, DefaultValue, VerificationFn, UpdateMethod}}
+    end.
+
+-spec check_update_method([module()], raw_module_parameter()) ->
+    {ok, module_parameter()} | {error, reason()}.
+check_update_method(Modules, {Name, Module, DefaultValue,
+                              VerificationMethod,
+                              UpdateMethod} = Attr) ->
+    case update_fun(Modules, UpdateMethod) of
+        not_exported -> {error, {update_method_not_exported, Attr, Modules}};
+        invalid_method -> {error, {invalid_update_method, Attr}};
+        UpdateFn -> {ok, {Name, Module, DefaultValue, VerificationMethod, UpdateFn}}
     end.
 
 -spec verification_fun([module()], maybe_verification_method()) ->
@@ -93,6 +120,19 @@ verification_fun(Modules, Atom) when is_atom(Atom) ->
 verification_fun(_, _) ->
     invalid_method.
 
+-spec update_fun([module()], maybe_update_method()) ->
+    update_fun() | not_exported | invalid_method | read_only.
+update_fun(_, read_only) ->
+    read_only;
+update_fun(_, none) ->
+    fun none/2;
+update_fun(_, Fun) when is_function(Fun, 2) ->
+    Fun;
+update_fun(Modules, Atom) when is_atom(Atom) ->
+    is_exported(Modules, Atom, 2);
+update_fun(_, _) ->
+    invalid_method.
+
 -spec is_exported([module()], atom(), non_neg_integer()) ->
     function() | not_exported.
 is_exported([], _, _) ->
@@ -104,6 +144,8 @@ is_exported([Module | T], Function, Arity) ->
     end.
 
 none(_) -> true.
+
+none(_, _) -> ok.
 
 -spec one_of_fun(one_of()) -> verification_fun().
 one_of_fun(OneOf) ->

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -78,11 +78,11 @@ maybe_convert_old_attribute_format({Name, Description}) ->
     {ok, #{name => Name, description => maybe_convert_description(Description)}};
 maybe_convert_old_attribute_format({Name, Description, DefaultValue}) ->
     {ok, #{name => Name, description => maybe_convert_description(Description),
-           value => DefaultValue}};
+           default_value => DefaultValue}};
 maybe_convert_old_attribute_format({Name, Description, DefaultValue,
                                     VerificationMethod}) ->
     {ok, #{name => Name, description => maybe_convert_description(Description),
-           value => DefaultValue, verification => VerificationMethod}};
+           default_value => DefaultValue, verification => VerificationMethod}};
 maybe_convert_old_attribute_format(Attr) ->
     {ok, Attr}.
 
@@ -99,8 +99,8 @@ check_mandatory_fields(_Attr) ->
 
 -spec check_default_value(maybe_module_attribute()) -> {ok, maybe_module_attribute()}.
 check_default_value(Attr) ->
-    DefaultValue = maps:get(value, Attr, undefined),
-    {ok, Attr#{value => DefaultValue}}.
+    DefaultValue = maps:get(default_value, Attr, undefined),
+    {ok, Attr#{default_value => DefaultValue}}.
 
 -spec check_verification_method(maybe_module_attribute(), [module()], module()) ->
     {ok, maybe_module_attribute()} | {error, reason()}.
@@ -135,7 +135,7 @@ check_update_method(Attr, VerificationModules, Module) ->
 
 -spec make_module_parameter(maybe_module_attribute(), module()) ->
     {ok, module_parameter()}.
-make_module_parameter(#{name := Name, value := Value, update := UpdateFn,
+make_module_parameter(#{name := Name, default_value := Value, update := UpdateFn,
                         verification := VerificationFn}, Module) ->
     {ok, #module_parameter{name = Name, mod = Module, value = Value,
                            verification_fn = VerificationFn, update_fn = UpdateFn}}.

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -2,9 +2,9 @@
 %% Copyright 2020 Erlang Solutions Ltd.
 %% Licensed under the Apache License, Version 2.0 (see LICENSE file)
 %%==============================================================================
-%% this module can be used directly only for the readonly env init parameters.
+%% This module can be used directly only for the readonly env init parameters.
 %% do not use it for the scenarios/helpers configuration, amoc_config module
-%% must be used instead! this allows to provide configuration via REST API in
+%% must be used instead! This allows to provide configuration via REST API in
 %% a JSON format
 %%==============================================================================
 -module(amoc_config_env).

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -2,22 +2,27 @@
 %% Copyright 2020 Erlang Solutions Ltd.
 %% Licensed under the Apache License, Version 2.0 (see LICENSE file)
 %%==============================================================================
+%% this module can be used directly only for the readonly env init parameters.
+%% do not use it for the scenarios/helpers configuration, amoc_config module
+%% must be used instead! this allows to provide configuration via REST API in
+%% a JSON format
+%%==============================================================================
 -module(amoc_config_env).
 
--export([get/1, get/2, parse_value/1]).
+-export([get/2, get/3, parse_value/1, find_all_vars/1]).
 
 -include_lib("kernel/include/logger.hrl").
 
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
--spec get(amoc_config:name()) -> amoc_config:value().
-get(Name) ->
-    get(Name, undefined).
+-spec get(atom(), amoc_config:name()) -> amoc_config:value().
+get(AppName, Name) ->
+    get(AppName, Name, undefined).
 
--spec get(amoc_config:name(), amoc_config:value()) -> amoc_config:value().
-get(Name, Default) when is_atom(Name) ->
-    DefValue = application:get_env(amoc, Name, Default),
+-spec get(atom(), amoc_config:name(), amoc_config:value()) -> amoc_config:value().
+get(AppName, Name, Default) when is_atom(Name) ->
+    DefValue = application:get_env(AppName, Name, Default),
     get_os_env(Name, DefValue).
 
 -spec parse_value(string() | binary()) -> {ok, amoc_config:value()} | {error, any()}.
@@ -30,6 +35,13 @@ parse_value(String) when is_list(String) ->
     catch
         _:E -> {error, E}
     end.
+
+-spec find_all_vars(atom()) -> [any()].
+find_all_vars(Name) ->
+    AllVars = [application:get_env(App, Name, [])
+               || {App, _, _} <- application:loaded_applications()],
+    lists:flatten(AllVars).
+
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -38,9 +38,9 @@ parse_value(String) when is_list(String) ->
 
 -spec find_all_vars(atom()) -> [any()].
 find_all_vars(Name) ->
-    AllVars = [application:get_env(App, Name, [])
-               || {App, _, _} <- application:loaded_applications()],
-    lists:flatten(AllVars).
+    AllValues = [application:get_env(App, Name)
+                 || {App, _, _} <- application:loaded_applications()],
+    [Value || {ok, Value} <- AllValues].
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -19,7 +19,7 @@ parse_scenario_settings(Module, Settings) when is_atom(Module) ->
     PipelineActions = [
         {fun get_configuration/1, [Module]},
         {fun verify_settings/2, [Settings]},
-        {fun amoc_config_validation:process_scenario_config/2, [Settings]},
+        {fun amoc_config_verification:process_scenario_config/2, [Settings]},
         {fun amoc_config_utils:store_scenario_config/1, []}],
     case amoc_config_utils:pipeline(PipelineActions, ok) of
         ok -> ok;
@@ -34,7 +34,7 @@ update_settings(Settings) ->
         {fun get_existing_configuration/0, []},
         {fun verify_settings/2, [Settings]},
         {fun filter_configuration/2, [Settings]},
-        {fun amoc_config_validation:process_scenario_config/2, [Settings]},
+        {fun amoc_config_verification:process_scenario_config/2, [Settings]},
         {fun store_scenario_config/1, []}],
     case amoc_config_utils:pipeline(PipelineActions, ok) of
         ok -> ok;

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -7,196 +7,67 @@
 %% API
 -export([parse_scenario_settings/2]).
 
--ifdef(TEST).
--export([%% exported for testing only
-         get_module_attributes/1,
-         process_scenario_attributes/2,
-         process_scenario_config/2]).
--endif.
-
--export_type([settings/0]).
-
--type reason() :: any().
--type validation_fun() :: fun((amoc_config:value()) -> boolean() |
-                                                       {true, amoc_config:value()} |
-                                                       {false, reason()}).
--type parameter_configuration() :: {amoc_config:name(),
-                                    DefValue :: amoc_config:value(),
-                                    validation_fun()}.
--type scenario_configuration() :: [parameter_configuration()].
-
--type parameter() :: {amoc_config:name(), amoc_config:value()}.
--type settings() :: [parameter()].
-
--type error_type() :: invalid_scenario_module | invalid_verification_module |
-                      invalid_attribute_format | parameters_verification_failed.
--type error() :: {error, error_type(), reason()}.
-
--type one_of() :: [amoc_config:value(), ...].
--type verification_method() :: one_of() | atom() | validation_fun().
--type scenario_attribute() ::
-    {amoc_config:name(), Description :: string()} |
-    {amoc_config:name(), Description :: string(), DefValue :: amoc_config:value()} |
-    {amoc_config:name(), Description :: string(), DefValue :: amoc_config:value(), verification_method()}.
--type maybe_scenario_attribute() :: scenario_attribute() | term().
-
 -include_lib("kernel/include/logger.hrl").
+-include("amoc_config.hrl").
 
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
 -spec parse_scenario_settings(module(), settings()) -> ok | error().
 parse_scenario_settings(Module, Settings) when is_atom(Module) ->
-    try get_scenario_configuration(Module) of
-        {ok, Config} ->
-            case process_scenario_config(Config, Settings) of
-                {ok, ScenarioSettings} ->
-                    store_scenario_settings(ScenarioSettings),
-                    ok;
-                Error -> Error
-            end;
-        {error, _, _} = Error -> Error
-    catch
-        _:_ -> {error, invalid_scenario_module, Module}
+    PipelineActions = [
+        {fun amoc_config_utils:load_verification_modules/0, []},
+        {fun get_configuration/2, [Module]},
+        {fun amoc_config_validation:process_scenario_config/2, [Settings]},
+        {fun amoc_config_utils:store_scenario_config/1, []}],
+    case amoc_config_utils:pipeline(PipelineActions, ok) of
+        ok -> ok;
+        {error, _, _} = Error -> Error;
+        UnexpectedReturnValue ->
+            {error, invalid_return_value, UnexpectedReturnValue}
     end.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
+-spec get_configuration([module()], module()) ->
+    {ok, module_configuration()} | error().
+get_configuration(VerificationModules, Module) ->
+    ParametrisedModules = amoc_scenario:list_parametrised_modules(),
+    AllParametrisedModules = [Module | ParametrisedModules],
+    PipelineActions = [
+        {fun compose_configuration/2, [AllParametrisedModules, VerificationModules]},
+        {fun override_configuration/3, [Module, VerificationModules]}],
+    amoc_config_utils:pipeline(PipelineActions, ok).
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% parsing scenario attributes %%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--spec get_scenario_configuration(module()) -> {ok,scenario_configuration()} | error().
-get_scenario_configuration(Module) ->
-    case load_verification_modules() of
-        {ok, VerificationModules} ->
-            ScenarioAttributes = get_module_attributes(Module),
-            AllVerificationModules = [Module | VerificationModules],
-            process_scenario_attributes(AllVerificationModules, ScenarioAttributes);
-        Error -> Error
+-spec compose_configuration([module()], [module()]) ->
+    {ok, module_configuration()} | error().
+compose_configuration(AllParametrisedModules, VerificationModules) ->
+    compose_configuration([], AllParametrisedModules, VerificationModules).
+
+-spec override_configuration(module_configuration(), module(), [module()]) ->
+    {ok, module_configuration()} | error().
+override_configuration(OldConfig, Module, VerificationModules) ->
+    AttrName = override_variable,
+    case amoc_config_attributes:get_module_configuration(AttrName, Module,
+                                                         VerificationModules) of
+        {ok, NewConfig} ->
+            amoc_config_utils:override_config(OldConfig, NewConfig);
+        {error, _, _} = Error -> Error
     end.
 
--spec load_verification_modules() -> {ok, [module()]} | error().
-load_verification_modules() ->
-    Modules = amoc_config_env:find_all_vars(config_verification_modules),
-    LoadingResult = [load_module(Module) || Module <- Modules],
-    maybe_error(invalid_verification_module, LoadingResult).
-
--spec load_module(module()) -> {ok, module()} | {error, {module(), any()}}.
-load_module(Module) ->
-    case code:ensure_loaded(Module) of
-        {module, Module} -> {ok, Module};
-        {error, Error} -> {error, {Module, Error}}
+-spec compose_configuration(module_configuration(), [module()], [module()]) ->
+    {ok, module_configuration()} | error().
+compose_configuration(Config, [], _) ->
+    {ok, Config};
+compose_configuration(Config, [M | L], VerificationModules) ->
+    AttrName = required_variable,
+    case amoc_config_attributes:get_module_configuration(AttrName, M, VerificationModules) of
+        {ok, NewConfig} ->
+            case amoc_config_utils:merge_config(Config, NewConfig) of
+                {ok, MergedConfig} ->
+                    compose_configuration(MergedConfig, L, VerificationModules);
+                {error, _, _} = Error -> Error
+            end;
+        {error, _, _} = Error -> Error
     end.
-
--spec get_module_attributes(module()) -> [maybe_scenario_attribute()].
-get_module_attributes(Module) ->
-    ModuleAttributes = apply(Module, module_info, [attributes]),
-    RequiredVariables = proplists:get_all_values(required_variable, ModuleAttributes),
-    lists:append(RequiredVariables).
-
--spec process_scenario_attributes([module()], [maybe_scenario_attribute()]) ->
-    {ok, scenario_configuration()} | error().
-process_scenario_attributes(VerificationModules, ScenarioAttributes) ->
-    Config = [process_var_attr(VerificationModules, Attr) || Attr <- ScenarioAttributes],
-    maybe_error(invalid_attribute_format, Config).
-
--spec process_var_attr([module()], maybe_scenario_attribute()) ->
-    {ok, parameter_configuration()} | {error, reason()}.
-process_var_attr(_, {Name, _}) when is_atom(Name) ->
-    {ok, {Name, undefined, fun none/1}};
-process_var_attr(_, {Name, _, DefaultValue}) when is_atom(Name) ->
-    {ok, {Name, DefaultValue, fun none/1}};
-process_var_attr(Modules, {Name, _, DefaultValue, Atom} = Attribute) when is_atom(Atom),
-                                                                          is_atom(Name) ->
-    case verification_method(Modules, Atom) of
-        not_exported -> {error, {verification_method_not_exported, Attribute, Modules}};
-        VerificationMethod -> {ok, {Name, DefaultValue, VerificationMethod}}
-    end;
-process_var_attr(_, {Name, _, DefaultValue, Fun}) when is_function(Fun, 1),
-                                                       is_atom(Name) ->
-    {ok, {Name, DefaultValue, Fun}};
-process_var_attr(_, {Name, _, DefaultValue, [_ | _] = OneOF}) when is_atom(Name) ->
-    {ok, {Name, DefaultValue, one_of_fun(OneOF)}};
-process_var_attr(_, {Name, _, _, _} = InvalidAttribute) when is_atom(Name) ->
-    {error, {invalid_verification_method, InvalidAttribute}};
-process_var_attr(_, InvalidAttribute) ->
-    {error, {invalid_attribute, InvalidAttribute}}.
-
--spec verification_method([module()], atom()) -> validation_fun() | not_exported.
-verification_method(_, none) -> fun none/1;
-verification_method([], _) ->
-    not_exported;
-verification_method([Module | T], Atom) ->
-    case erlang:function_exported(Module, Atom, 1) of
-        true -> fun Module:Atom/1;
-        false -> verification_method(T, Atom)
-    end.
-
-none(_) -> true.
-
--spec one_of_fun(one_of()) -> validation_fun().
-one_of_fun(OneOf) ->
-    fun(X) ->
-        case lists:member(X, OneOf) of
-            true -> true;
-            false -> {false, {not_one_of, OneOf}}
-        end
-    end.
-
--spec maybe_error(error_type(), [{error, reason()} | {ok, any()}]) -> error() | {ok, [any()]}.
-maybe_error(ErrorType, List) ->
-    case [Error || {error, Error} <- List] of
-        [] ->
-            {ok, [CorrectValue || {ok, CorrectValue} <- List]};
-        Error ->
-            {error, ErrorType, Error}
-    end.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% processing scenario configuration %%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--spec process_scenario_config(scenario_configuration(), settings()) ->
-    {ok, settings()} | error().
-process_scenario_config(Config, Settings) ->
-    ParametersVerification = [get_value_and_verify(C, Settings) || C <- Config],
-    maybe_error(parameters_verification_failed, ParametersVerification).
-
--spec get_value_and_verify(parameter_configuration(), settings()) ->
-    {ok, parameter()} | {error, reason()}.
-get_value_and_verify({Name, Default, VerificationMethod}, Settings) ->
-    DefaultValue = amoc_config_env:get(amoc, Name, Default),
-    Value = proplists:get_value(Name, Settings, DefaultValue),
-    case verify(VerificationMethod, Value) of
-        {true, NewValue} -> {ok, {Name, NewValue}};
-        {false, Reason} -> {error, {Name, Value, Reason}}
-    end.
-
-
--spec verify(validation_fun(), amoc_config:value()) -> {true, amoc_config:value()} |
-                                                       {false, reason()}.
-verify(Fun, Value) ->
-    try apply(Fun, [Value]) of
-        true -> {true, Value};
-        false -> {false, verification_failed};
-        {true, NewValue} -> {true, NewValue};
-        {false, Reason} -> {false, {verification_failed, Reason}};
-        Ret ->
-            ?LOG_ERROR("invalid verification method ~p(~p), return value : ~p",
-                       [Fun, Value, Ret]),
-            {false, {invalid_verification_return_value, Ret}}
-    catch
-        C:E:S ->
-            ?LOG_ERROR("invalid verification method ~p(~p), exception: ~p ~p ~p",
-                       [Fun, Value, C, E, S]),
-            {false, {exception_durin_verification, {C, E, S}}}
-    end.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% store scenario settings %%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--spec store_scenario_settings(settings()) -> true.
-store_scenario_settings(Settings) ->
-    ValidSettings = [{K, V} || {K, V} <- Settings, is_atom(K)],
-    true = ets:insert(amoc_config, ValidSettings).

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -79,7 +79,7 @@ get_scenario_configuration(Module) ->
 
 -spec load_verification_modules() -> {ok, [module()]} | error().
 load_verification_modules() ->
-    Modules = amoc_config_env:get(config_verification_modules, []),
+    Modules = amoc_config_env:find_all_vars(config_verification_modules),
     LoadingResult = [load_module(Module) || Module <- Modules],
     maybe_error(invalid_verification_module, LoadingResult).
 
@@ -166,7 +166,7 @@ process_scenario_config(Config, Settings) ->
 -spec get_value_and_verify(parameter_configuration(), settings()) ->
     {ok, parameter()} | {error, reason()}.
 get_value_and_verify({Name, Default, VerificationMethod}, Settings) ->
-    DefaultValue = amoc_config_env:get(Name, Default),
+    DefaultValue = amoc_config_env:get(amoc, Name, Default),
     Value = proplists:get_value(Name, Settings, DefaultValue),
     case verify(VerificationMethod, Value) of
         {true, NewValue} -> {ok, {Name, NewValue}};

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -49,17 +49,17 @@ update_settings(Settings) ->
 -spec get_configuration(module()) ->
     {ok, module_configuration()} | error().
 get_configuration(Module) ->
-    ParametrisedModules = amoc_scenario:list_parametrised_modules(),
-    AllParametrisedModules = [Module | ParametrisedModules],
+    ConfigurableModules = amoc_scenario:list_configurable_modules(),
+    AllConfigurableModules = [Module | ConfigurableModules],
     PipelineActions = [
-        {fun compose_configuration/1, [AllParametrisedModules]},
+        {fun compose_configuration/1, [AllConfigurableModules]},
         {fun override_configuration/2, [Module]}],
     amoc_config_utils:pipeline(PipelineActions, ok).
 
 -spec compose_configuration([module()]) ->
     {ok, module_configuration()} | error().
-compose_configuration(AllParametrisedModules) ->
-    compose_configuration([], AllParametrisedModules).
+compose_configuration(AllConfigurableModules) ->
+    compose_configuration([], AllConfigurableModules).
 
 -spec override_configuration(module_configuration(), module()) ->
     {ok, module_configuration()} | error().

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -17,10 +17,15 @@
 
 -spec load_verification_modules() -> {ok, [module()]} | error().
 load_verification_modules() ->
-    Modules = amoc_config_env:find_all_vars(config_verification_modules),
-    UniqueModules = lists:usort(lists:concat(Modules)),
-    LoadingResult = [load_module(Module) || Module <- UniqueModules],
+    Modules = get_all_verification_modules(),
+    LoadingResult = [load_module(Module) || Module <- Modules],
     maybe_error(invalid_verification_module, LoadingResult).
+
+-spec get_all_verification_modules() -> [module()].
+get_all_verification_modules() ->
+    ModuleSets = amoc_config_env:find_all_vars(config_verification_modules),
+    Modules = lists:flatten(ModuleSets),
+    lists:usort(Modules).
 
 -spec load_module(module()) -> {ok, module()} | {error, {module(), any()}}.
 load_module(Module) ->
@@ -80,6 +85,7 @@ store_scenario_config(Config) ->
     true = ets:insert(amoc_config, Config),
     ok.
 
+-spec create_amoc_config_ets() -> any().
 create_amoc_config_ets() ->
     amoc_config = ets:new(amoc_config, [named_table,
                                         protected,

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -18,7 +18,8 @@
 -spec load_verification_modules() -> {ok, [module()]} | error().
 load_verification_modules() ->
     Modules = amoc_config_env:find_all_vars(config_verification_modules),
-    LoadingResult = [load_module(Module) || Module <- Modules],
+    UniqueModules = lists:usort(lists:concat(Modules)),
+    LoadingResult = [load_module(Module) || Module <- UniqueModules],
     maybe_error(invalid_verification_module, LoadingResult).
 
 -spec load_module(module()) -> {ok, module()} | {error, {module(), any()}}.

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -58,11 +58,11 @@ try_apply_fn(Fun, Args) ->
     {ok, module_configuration()} | error().
 merge_config(MergedConfig, []) ->
     {ok, MergedConfig};
-merge_config(OldConfig, [{ParamName, Module, _, _} = Param | L]) ->
+merge_config(OldConfig, [{ParamName, Module, _, _, _} = Param | L]) ->
     case lists:keyfind(ParamName, 1, OldConfig) of
         false ->
             merge_config([Param | OldConfig], L);
-        {ParamName, AnotherModule, _, _} ->
+        {ParamName, AnotherModule, _, _, _} ->
             {error, parameter_overriding, {ParamName, Module, AnotherModule}}
     end.
 

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -7,32 +7,12 @@
 -include("amoc_config.hrl").
 
 %% API
--export([load_verification_modules/0,
-         maybe_error/2,
+-export([maybe_error/2,
          pipeline/2,
          merge_config/2,
          override_config/2,
          store_scenario_config/1,
          create_amoc_config_ets/0]).
-
--spec load_verification_modules() -> {ok, [module()]} | error().
-load_verification_modules() ->
-    Modules = get_all_verification_modules(),
-    LoadingResult = [load_module(Module) || Module <- Modules],
-    maybe_error(invalid_verification_module, LoadingResult).
-
--spec get_all_verification_modules() -> [module()].
-get_all_verification_modules() ->
-    ModuleSets = amoc_config_env:find_all_vars(config_verification_modules),
-    Modules = lists:flatten(ModuleSets),
-    lists:usort(Modules).
-
--spec load_module(module()) -> {ok, module()} | {error, {module(), any()}}.
-load_module(Module) ->
-    case code:ensure_loaded(Module) of
-        {module, Module} -> {ok, Module};
-        {error, Error} -> {error, {Module, Error}}
-    end.
 
 -spec maybe_error(error_type(), [{error, reason()} | {ok, any()}]) ->
     error() | {ok, [any()]}.

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -1,0 +1,79 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+-module(amoc_config_utils).
+
+-include("amoc_config.hrl").
+
+%% API
+-export([load_verification_modules/0,
+         maybe_error/2,
+         pipeline/2,
+         merge_config/2,
+         override_config/2,
+         store_scenario_config/1]).
+
+-spec load_verification_modules() -> {ok, [module()]} | error().
+load_verification_modules() ->
+    Modules = amoc_config_env:find_all_vars(config_verification_modules),
+    LoadingResult = [load_module(Module) || Module <- Modules],
+    maybe_error(invalid_verification_module, LoadingResult).
+
+-spec load_module(module()) -> {ok, module()} | {error, {module(), any()}}.
+load_module(Module) ->
+    case code:ensure_loaded(Module) of
+        {module, Module} -> {ok, Module};
+        {error, Error} -> {error, {Module, Error}}
+    end.
+
+-spec maybe_error(error_type(), [{error, reason()} | {ok, any()}]) ->
+    error() | {ok, [any()]}.
+maybe_error(ErrorType, List) ->
+    case [Reason || {error, Reason} <- List] of
+        [] ->
+            {ok, [CorrectValue || {ok, CorrectValue} <- List]};
+        Errors ->
+            {error, ErrorType, Errors}
+    end.
+
+-spec pipeline([{function(), Args :: [any()]}], any()) -> any().
+pipeline(Actions, InitValue) ->
+    lists:foldl(fun run_action/2, InitValue, Actions).
+
+run_action({Fun, Args}, {ok, FirstArg}) ->
+    try_apply_fn(Fun, [FirstArg | Args]);
+run_action({Fun, Args}, ok) ->
+    try_apply_fn(Fun, Args);
+run_action(_, Error) -> Error.
+
+try_apply_fn(Fun, Args) ->
+    try
+        apply(Fun, Args)
+    catch
+        C:E:S -> {error, pipeline_action_crashed, {C, E, S}}
+    end.
+
+-spec merge_config(module_configuration(), module_configuration()) ->
+    {ok, module_configuration()} | error().
+merge_config(MergedConfig, []) ->
+    {ok, MergedConfig};
+merge_config(OldConfig, [{ParamName, Module, _, _} = Param | L]) ->
+    case lists:keyfind(ParamName, 1, OldConfig) of
+        false ->
+            merge_config([Param | OldConfig], L);
+        {ParamName, AnotherModule, _, _} ->
+            {error, parameter_overriding, {ParamName, Module, AnotherModule}}
+    end.
+
+-spec override_config(module_configuration(), module_configuration()) ->
+    {ok, module_configuration()}.
+override_config(OldConfig,NewConfig)->
+    ReversedNewConfig = lists:reverse(NewConfig),
+    FullConfig = ReversedNewConfig ++ OldConfig,
+    {ok, lists:ukeysort(1,FullConfig)}.
+
+-spec store_scenario_config(module_configuration()) -> ok.
+store_scenario_config(Config) ->
+    true = ets:insert(amoc_config, Config),
+    ok.

--- a/src/amoc_config/amoc_config_validation.erl
+++ b/src/amoc_config/amoc_config_validation.erl
@@ -1,0 +1,57 @@
+%%==============================================================================
+%% Copyright 2020 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+%% this module is responsible for processing scenario configuration
+%%==============================================================================
+-module(amoc_config_validation).
+
+%% API
+-export([process_scenario_config/2]).
+
+-include_lib("kernel/include/logger.hrl").
+-include("amoc_config.hrl").
+
+-spec process_scenario_config(module_configuration(), settings()) ->
+    {ok, module_configuration()} | error().
+process_scenario_config(Config, Settings) ->
+    ParametersVerification = [get_value_and_verify(Param, Settings) || Param <- Config],
+    amoc_config_utils:maybe_error(parameters_verification_failed, ParametersVerification).
+
+-spec get_value_and_verify(module_parameter(), settings()) ->
+    {ok, module_parameter()} | {error, reason()}.
+get_value_and_verify({Name, Module, Default, VerificationMethod}, Settings) ->
+    App = get_application(Module),
+    DefaultValue = amoc_config_env:get(App, Name, Default),
+    Value = proplists:get_value(Name, Settings, DefaultValue),
+    case verify(VerificationMethod, Value) of
+        {true, NewValue} ->
+            {ok, {Name, Module, NewValue, VerificationMethod}};
+        {false, Reason} ->
+            {error, {Name, Value, Reason}}
+    end.
+
+-spec verify(verification_fun(), value()) -> {true, value()} | {false, reason()}.
+verify(Fun, Value) ->
+    try apply(Fun, [Value]) of
+        true -> {true, Value};
+        false -> {false, verification_failed};
+        {true, NewValue} -> {true, NewValue};
+        {false, Reason} -> {false, {verification_failed, Reason}};
+        Ret ->
+            ?LOG_ERROR("invalid verification method ~p(~p), return value : ~p",
+                       [Fun, Value, Ret]),
+            {false, {invalid_verification_return_value, Ret}}
+    catch
+        C:E:S ->
+            ?LOG_ERROR("invalid verification method ~p(~p), exception: ~p ~p ~p",
+                       [Fun, Value, C, E, S]),
+            {false, {exception_during_verification, {C, E, S}}}
+    end.
+
+-spec get_application(module()) -> atom().
+get_application(Module) ->
+    case application:get_application(Module) of
+        undefined -> amoc;
+        {ok, App} -> App
+    end.

--- a/src/amoc_config/amoc_config_validation.erl
+++ b/src/amoc_config/amoc_config_validation.erl
@@ -20,13 +20,13 @@ process_scenario_config(Config, Settings) ->
 
 -spec get_value_and_verify(module_parameter(), settings()) ->
     {ok, module_parameter()} | {error, reason()}.
-get_value_and_verify({Name, Module, Default, VerificationMethod}, Settings) ->
+get_value_and_verify({Name, Module, Default, VerificationMethod, UpdateMethod}, Settings) ->
     App = get_application(Module),
     DefaultValue = amoc_config_env:get(App, Name, Default),
     Value = proplists:get_value(Name, Settings, DefaultValue),
     case verify(VerificationMethod, Value) of
         {true, NewValue} ->
-            {ok, {Name, Module, NewValue, VerificationMethod}};
+            {ok, {Name, Module, NewValue, VerificationMethod, UpdateMethod}};
         {false, Reason} ->
             {error, {Name, Value, Reason}}
     end.

--- a/src/amoc_config/amoc_config_verification.erl
+++ b/src/amoc_config/amoc_config_verification.erl
@@ -4,7 +4,7 @@
 %%==============================================================================
 %% this module is responsible for processing scenario configuration
 %%==============================================================================
--module(amoc_config_validation).
+-module(amoc_config_verification).
 
 %% API
 -export([process_scenario_config/2]).

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -157,7 +157,7 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(any(), state()) -> {noreply, state()}.
 handle_cast(maybe_update_interarrival_timer, State) ->
-    {noreply,maybe_update_interarrival_timer(State)};
+    {noreply, maybe_update_interarrival_timer(State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -303,7 +303,7 @@ dec_no_of_users(#state{no_of_users = N} = State) ->
 
 -spec interarrival() -> interarrival().
 interarrival() ->
-    amoc_config_env:get(interarrival, ?INTERARRIVAL_DEFAULT).
+    amoc_config_env:get(amoc, interarrival, ?INTERARRIVAL_DEFAULT).
 
 -spec apply_safely(atom(), atom(), [term()]) -> {ok | error, term()}.
 apply_safely(M, F, A) ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -8,7 +8,8 @@
 -define(SERVER, ?MODULE).
 -define(USERS_TABLE, amoc_users).
 
--required_variable(#{name => interarrival, value => 50, verification => positive_integer,
+-required_variable(#{name => interarrival, default_value => 50,
+                     verification => positive_integer,
                      description => "a delay between creating the processes for two "
                                     "consecutive users (ms, def: 50ms)",
                      update => maybe_update_interarrival_timer}).

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -111,6 +111,7 @@ get_status() ->
 disable() ->
     gen_server:call(?SERVER, disable).
 
+-spec positive_integer(any()) -> boolean().
 positive_integer(Interarrival) ->
     is_integer(Interarrival) andalso Interarrival > 0.
 

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -271,9 +271,7 @@ start_tables() -> %% ETS creation
                                           ordered_set,
                                           protected,
                                           {read_concurrency, true}]),
-    amoc_config = ets:new(amoc_config, [named_table,
-                                        protected,
-                                        {read_concurrency, true}]),
+    amoc_config_utils:create_amoc_config_ets(),
     ok.
 
 -spec init_scenario(amoc:scenario(), amoc_config:settings()) ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -8,9 +8,9 @@
 -define(SERVER, ?MODULE).
 -define(USERS_TABLE, amoc_users).
 
--required_variable({interarrival, "a delay between creating the processes "
-                                  "for two consecutive users (ms, def: 50ms)",
-                    50, positive_integer}).
+-required_variable(#{name => interarrival, value => 50, verification => positive_integer,
+                     description => "a delay between creating the processes for two "
+                                    "consecutive users (ms, def: 50ms)"}).
 
 -record(state, {scenario :: amoc:scenario() | undefined,
                 no_of_users = 0 :: user_count(),
@@ -55,7 +55,7 @@
          disable/0]).
 
 %% ------------------------------------------------------------------
-%% Parameters validation functions
+%% Parameters verification functions
 %% ------------------------------------------------------------------
 -export([positive_integer/1]).
 %% ------------------------------------------------------------------

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -9,10 +9,10 @@
 -define(USERS_TABLE, amoc_users).
 
 -required_variable(#{name => interarrival, default_value => 50,
-                     verification => positive_integer,
+                     verification => fun ?MODULE:positive_integer/1,
                      description => "a delay between creating the processes for two "
                                     "consecutive users (ms, def: 50ms)",
-                     update => maybe_update_interarrival_timer}).
+                     update => fun ?MODULE:maybe_update_interarrival_timer/2}).
 
 -record(state, {scenario :: amoc:scenario() | undefined,
                 no_of_users = 0 :: user_count(),

--- a/src/amoc_distribution/amoc_cluster.erl
+++ b/src/amoc_distribution/amoc_cluster.erl
@@ -50,7 +50,7 @@
 %% ------------------------------------------------------------------
 -spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
-    Nodes = amoc_config_env:get(nodes, []),
+    Nodes = amoc_config_env:get(amoc, nodes, []),
     gen_server:start_link({local, ?SERVER}, ?MODULE, Nodes, []).
 
 -spec connect_nodes([node()]) -> ok.

--- a/src/amoc_distribution/amoc_dist.erl
+++ b/src/amoc_distribution/amoc_dist.erl
@@ -125,10 +125,13 @@ setup_slave_node(Node) ->
 
 -spec propagate_uploaded_modules(node()) -> {ok, any()} | {error, any()}.
 propagate_uploaded_modules(Node) ->
-    UploadedModules = ets:match(amoc_scenarios, {'$1', '_', {uploaded, '$2'}}),
-    Result = [{Module, rpc:call(Node, amoc_scenario, install_scenario, Args)} ||
-                 [Module, _] = Args <- UploadedModules],
+    UploadedModules = amoc_scenario:list_uploaded_modules(),
+    Result = [{Module, propagate_module(Node, Module, SourceCode)}
+              || {Module, SourceCode} <- UploadedModules],
     maybe_error(Result).
+
+propagate_module(Node, Module, SourceCode) ->
+    rpc:call(Node, amoc_scenario, install_module, [Module, SourceCode]).
 
 -spec add_users(pos_integer(), [node()]) -> {ok, any()} | {error, any()}.
 add_users(Count, Nodes) ->

--- a/src/amoc_distribution/amoc_dist.erl
+++ b/src/amoc_distribution/amoc_dist.erl
@@ -15,7 +15,7 @@
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
--spec do(amoc:scenario(), non_neg_integer(), amoc_config_scenario:config()) ->
+-spec do(amoc:scenario(), non_neg_integer(), amoc_config:settings()) ->
     {ok, any()} | {error, any()}.
 do(Scenario, Count, Settings) ->
     case {prepare_cluster(Scenario, Settings), Count} of
@@ -83,7 +83,7 @@ check_nodes(Nodes) ->
             {error, not_a_master}
     end.
 
--spec prepare_cluster(amoc:scenario(), amoc_config_scenario:config()) -> {ok, any()} | {error, any()}.
+-spec prepare_cluster(amoc:scenario(), amoc_config:settings()) -> {ok, any()} | {error, any()}.
 prepare_cluster(Scenario, Settings) ->
     case setup_master_node() of
         ok ->

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -118,4 +118,4 @@ maybe_subscribe(ExName, Datapoints) ->
 
 maybe_init_predefined_metrics() ->
     Preconfigured = amoc_config_env:find_all_vars(predefined_metrics),
-    [init(Type, Name) || {Type, Name} <- Preconfigured].
+    [init(Type, Name) || {Type, Name} <- lists:concat(Preconfigured)].

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -22,7 +22,7 @@
 start() ->
     maybe_add_reporter(),
     subsribe_default_metrics(),
-    maybe_init_preconfigured_metrics().
+    maybe_init_predefined_metrics().
 
 -spec init(type(), name()) -> ok.
 init(Type, Name) ->
@@ -83,11 +83,11 @@ maybe_add_reporter() ->
     case lists:keyfind(Reporter, 1, exometer_report:list_reporters()) of
         {Reporter, _} -> ok;
         _->
-            case amoc_config_env:get(graphite_host) of
+            case amoc_config_env:get(amoc, graphite_host) of
                 undefined -> ok;
                 Host ->
-                    Prefix = amoc_config_env:get(graphite_prefix, net_adm:localhost()),
-                    Port = amoc_config_env:get(graphite_port, 2003),
+                    Prefix = amoc_config_env:get(amoc, graphite_prefix, net_adm:localhost()),
+                    Port = amoc_config_env:get(amoc, graphite_port, 2003),
                     Options = [{module, exometer_report_graphite},
                                {prefix, Prefix},
                                {host, Host},
@@ -103,7 +103,7 @@ subsribe_default_metrics() ->
     maybe_subscribe([erlang, memory], [total, processes, processes_used, system, binary, ets]).
 
 get_reporter() ->
-    amoc_config_env:get(metrics_reporter, ?AMOC_DEFAULT_METRICS_REPORTER).
+    amoc_config_env:get(amoc, metrics_reporter, ?AMOC_DEFAULT_METRICS_REPORTER).
 
 maybe_subscribe(ExName, Datapoints) ->
     Reporter = get_reporter(),
@@ -116,6 +116,6 @@ maybe_subscribe(ExName, Datapoints) ->
             ?LOG_WARNING("Reporter=~p not_enbled", [Reporter])
     end.
 
-maybe_init_preconfigured_metrics() ->
-    Preconfigured = amoc_config_env:get(metrics_preconfigured, []),
+maybe_init_predefined_metrics() ->
+    Preconfigured = amoc_config_env:find_all_vars(predefined_metrics),
     [init(Type, Name) || {Type, Name} <- Preconfigured].

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -118,4 +118,4 @@ maybe_subscribe(ExName, Datapoints) ->
 
 maybe_init_predefined_metrics() ->
     Preconfigured = amoc_config_env:find_all_vars(predefined_metrics),
-    [init(Type, Name) || {Type, Name} <- lists:concat(Preconfigured)].
+    [init(Type, Name) || {Type, Name} <- lists:flatten(Preconfigured)].

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -125,7 +125,11 @@ maybe_store_module(Module) ->
 -spec get_module_type(module()) -> scenario | configurable | ordinary.
 get_module_type(Module) ->
     case erlang:function_exported(Module, module_info, 1) of
-        false -> ordinary;
+        false ->
+            %% This can happen with the mocked (meck:new/2) and
+            %% later unloaded (meck:unload/1) module. So this
+            %% clause is required to pass the tests.
+            ordinary;
         true ->
             ModuleAttributes = apply(Module, module_info, [attributes]),
             lists:foldl(fun({behaviour, [?MODULE]}, _) -> scenario;

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -104,7 +104,7 @@ add_code_paths() ->
         BadDirectories -> {error, {bad_directories, BadDirectories}}
     end.
 
--spec find_scenario_modules() -> any().
+-spec find_scenario_modules() -> [module()].
 find_scenario_modules() ->
     AllBeamFiles = [File || Path <- code:get_path(), File <- filelib:wildcard("*.beam", Path)],
     AllModules = [list_to_atom(filename:rootname(BeamFile)) || BeamFile <- AllBeamFiles],

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -97,7 +97,7 @@ start_scenarios_ets() ->
 -spec add_code_paths() -> ok | {error, {bad_directories, [file:filename()]}}.
 add_code_paths() ->
     true = code:add_pathz(?EBIN_DIR),
-    AdditionalCodePaths = amoc_config_env:get(extra_code_paths, []),
+    AdditionalCodePaths = amoc_config_env:get(amoc, extra_code_paths, []),
     Res = [{code:add_pathz(Path), Path} || Path <- [?EBIN_DIR | AdditionalCodePaths]],
     case [Dir || {{error, bad_directory}, Dir} <- Res] of
         [] -> ok;

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -5,9 +5,11 @@
 -module(amoc_scenario).
 %% API
 -export([start_link/0,
-         install_scenario/2,
+         install_module/2,
          does_scenario_exist/1,
-         list_scenario_modules/0]).
+         list_scenario_modules/0,
+         list_uploaded_modules/0,
+         list_parametrised_modules/0]).
 
 -behaviour(gen_server).
 %% gen_server callbacks
@@ -23,6 +25,7 @@
 
 -type user_id() :: pos_integer().
 -type state() :: any().
+-type sourcecode() :: binary().
 
 -callback init() -> {ok, state()} | ok | {error, Reason :: term()}.
 -callback start(user_id(), state()) -> any().
@@ -40,10 +43,10 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec install_scenario(module(), binary()) ->
+-spec install_module(module(), sourcecode()) ->
     ok | {error, [Errors :: string()], [Warnings :: string()]}.
-install_scenario(Module, ModuleSource) ->
-    gen_server:call(?MODULE, {add_scenario, Module, ModuleSource}).
+install_module(Module, ModuleSource) ->
+    gen_server:call(?MODULE, {add_module, Module, ModuleSource}).
 
 -spec does_scenario_exist(module()) -> boolean().
 does_scenario_exist(Scenario) ->
@@ -52,8 +55,15 @@ does_scenario_exist(Scenario) ->
 
 -spec list_scenario_modules() -> [module()].
 list_scenario_modules() ->
-    [S || [S] <- ets:match(amoc_scenarios, {'$1',scenario,'_'})].
+    [S || [S] <- ets:match(amoc_scenarios, {'$1', scenario})].
 
+-spec list_uploaded_modules() -> [{module(), sourcecode()}].
+list_uploaded_modules() ->
+    ets:tab2list(uploaded_modules).
+
+-spec list_parametrised_modules() -> [module()].
+list_parametrised_modules() ->
+    [S || [S] <- ets:match(amoc_scenarios, {'$1', parametrised})].
 %%-------------------------------------------------------------------------
 %% gen_server callbacks
 %%-------------------------------------------------------------------------
@@ -65,8 +75,8 @@ init([]) ->
     {ok, ok}.
 
 -spec handle_call(any(), any(), state()) -> {reply, any(), state()}.
-handle_call({add_scenario, Module, ModuleSource}, _, State) ->
-    Reply = add_scenario(Module, ModuleSource),
+handle_call({add_module, Module, ModuleSource}, _, State) ->
+    Reply = add_module(Module, ModuleSource),
     {reply, Reply, State};
 handle_call(_, _, State) ->
     {reply, {error, not_implemented}, State}.
@@ -80,9 +90,9 @@ handle_cast(_, State) ->
 %%-------------------------------------------------------------------------
 -spec start_scenarios_ets() -> amoc_scenarios.
 start_scenarios_ets() ->
-    ets:new(amoc_scenarios, [named_table,
-                             protected,
-                             {read_concurrency, true}]).
+    EtsOptions = [named_table, protected, {read_concurrency, true}],
+    ets:new(amoc_scenarios, EtsOptions),
+    ets:new(uploaded_modules, EtsOptions).
 
 -spec add_code_paths() -> ok | {error, {bad_directories, [file:filename()]}}.
 add_code_paths() ->
@@ -94,33 +104,44 @@ add_code_paths() ->
         BadDirectories -> {error, {bad_directories, BadDirectories}}
     end.
 
--spec find_scenario_modules() -> [module()].
+-spec find_scenario_modules() -> any().
 find_scenario_modules() ->
     AllBeamFiles = [File || Path <- code:get_path(), File <- filelib:wildcard("*.beam", Path)],
     AllModules = [list_to_atom(filename:rootname(BeamFile)) || BeamFile <- AllBeamFiles],
     ok = code:ensure_modules_loaded(AllModules),
-    AllScenarios = [Module || Module <- erlang:loaded(), is_scenario(Module)],
-    [ets:insert(amoc_scenarios, {Scenario, scenario, preloaded}) || Scenario <- AllScenarios].
+    [maybe_store_module(Module) || Module <- erlang:loaded()].
 
--spec is_scenario(module()) -> boolean().
-is_scenario(Module) ->
-    case erlang:function_exported(Module, module_info, 1) of
-        false -> false;
-        true ->
-            ModuleAttributes = apply(Module, module_info, [attributes]),
-            lists:any(fun({behaviour, [?MODULE]}) -> true;
-                         ({behavior, [?MODULE]}) -> true;
-                         (_) -> false
-                      end, ModuleAttributes)
+-spec maybe_store_module(module()) -> any().
+maybe_store_module(Module) ->
+    case get_module_type(Module) of
+        scenario ->
+            ets:insert(amoc_scenarios, {Module, scenario});
+        parametrised ->
+            ets:insert(amoc_scenarios, {Module, parametrised});
+        ordinary ->
+            ok
     end.
 
--spec add_scenario(module(), binary()) ->
+-spec get_module_type(module()) -> scenario | parametrised | ordinary.
+get_module_type(Module) ->
+    case erlang:function_exported(Module, module_info, 1) of
+        false -> ordinary;
+        true ->
+            ModuleAttributes = apply(Module, module_info, [attributes]),
+            lists:foldl(fun({behaviour, [?MODULE]}, _) -> scenario;
+                           ({behavior, [?MODULE]}, _) -> scenario;
+                           ({required_variable, _}, ordinary) -> parametrised;
+                           (_, Ret) -> Ret
+                        end, ordinary, ModuleAttributes)
+    end.
+
+-spec add_module(module(), sourcecode()) ->
     ok | {error, [Errors :: string()], [Warnings :: string()]}.
-add_scenario(Module, ModuleSource) ->
+add_module(Module, ModuleSource) ->
     case erlang:module_loaded(Module) of
         true ->
-            case ets:lookup(amoc_scenarios, Module) of
-                [{Module, _, {uploaded, ModuleSource}}] -> ok;
+            case ets:lookup(uploaded_modules, Module) of
+                [{Module, ModuleSource}] -> ok;
                 _ -> {error, ["module with such name already exists"], []}
             end;
         false ->
@@ -128,11 +149,8 @@ add_scenario(Module, ModuleSource) ->
             write_scenario_to_file(ModuleSource, ScenarioPath),
             case compile_and_load_scenario(ScenarioPath) of
                 {ok, Module} ->
-                    Type = case is_scenario(Module) of
-                               true -> scenario;
-                               false -> helper
-                           end,
-                    ets:insert(amoc_scenarios, {Module, Type, {uploaded, ModuleSource}}),
+                    maybe_store_module(Module),
+                    ets:insert(uploaded_modules, {Module, ModuleSource}),
                     ok;
                 Error -> Error
             end
@@ -142,7 +160,7 @@ add_scenario(Module, ModuleSource) ->
 scenario_path_name(Module) -> %% w/o ".erl" extension
     filename:join([?PRIV_DIR, "scenarios", atom_to_list(Module)]).
 
--spec write_scenario_to_file(binary(), file:filename()) -> ok.
+-spec write_scenario_to_file(sourcecode(), file:filename()) -> ok.
 write_scenario_to_file(ModuleSource, ScenarioPath) ->
     ok = file:write_file(ScenarioPath ++ ".erl", ModuleSource, [write]).
 

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -9,7 +9,7 @@
          does_scenario_exist/1,
          list_scenario_modules/0,
          list_uploaded_modules/0,
-         list_parametrised_modules/0]).
+         list_configurable_modules/0]).
 
 -behaviour(gen_server).
 %% gen_server callbacks
@@ -61,9 +61,9 @@ list_scenario_modules() ->
 list_uploaded_modules() ->
     ets:tab2list(uploaded_modules).
 
--spec list_parametrised_modules() -> [module()].
-list_parametrised_modules() ->
-    [S || [S] <- ets:match(amoc_scenarios, {'$1', parametrised})].
+-spec list_configurable_modules() -> [module()].
+list_configurable_modules() ->
+    [S || [S] <- ets:match(amoc_scenarios, {'$1', configurable})].
 %%-------------------------------------------------------------------------
 %% gen_server callbacks
 %%-------------------------------------------------------------------------
@@ -116,13 +116,13 @@ maybe_store_module(Module) ->
     case get_module_type(Module) of
         scenario ->
             ets:insert(amoc_scenarios, {Module, scenario});
-        parametrised ->
-            ets:insert(amoc_scenarios, {Module, parametrised});
+        configurable ->
+            ets:insert(amoc_scenarios, {Module, configurable});
         ordinary ->
             ok
     end.
 
--spec get_module_type(module()) -> scenario | parametrised | ordinary.
+-spec get_module_type(module()) -> scenario | configurable | ordinary.
 get_module_type(Module) ->
     case erlang:function_exported(Module, module_info, 1) of
         false -> ordinary;
@@ -130,7 +130,7 @@ get_module_type(Module) ->
             ModuleAttributes = apply(Module, module_info, [attributes]),
             lists:foldl(fun({behaviour, [?MODULE]}, _) -> scenario;
                            ({behavior, [?MODULE]}, _) -> scenario;
-                           ({required_variable, _}, ordinary) -> parametrised;
+                           ({required_variable, _}, ordinary) -> configurable;
                            (_, Ret) -> Ret
                         end, ordinary, ModuleAttributes)
     end.

--- a/src/rest_api/amoc_api.erl
+++ b/src/rest_api/amoc_api.erl
@@ -9,7 +9,7 @@
 -spec start() -> {ok, pid()} | {error, any()}.
 start() ->
     LogicHandler = amoc_api_logic_handler,
-    Port = amoc_config_env:get(api_port, 4000),
+    Port = amoc_config_env:get(amoc, api_port, 4000),
     ServerParams = #{ip => {0, 0, 0, 0}, port => Port, net_opts => [],
                      logic_handler => LogicHandler},
     amoc_rest_server:start(http_server, ServerParams).

--- a/src/rest_api/amoc_api_upload_scenario.erl
+++ b/src/rest_api/amoc_api_upload_scenario.erl
@@ -33,7 +33,7 @@ get_module_name(SourceCode) ->
     end.
 
 install_scenario_on_nodes(Nodes, Module, ModuleSource) ->
-    rpc:multicall(Nodes, amoc_scenario, install_scenario, [Module, ModuleSource]).
+    rpc:multicall(Nodes, amoc_scenario, install_module, [Module, ModuleSource]).
 
 process_multicall_results({Results, []}) ->
     case lists:all(fun(X) -> X == ok end, Results) of

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -52,5 +52,5 @@ request(BaseUrl, Path, Method, RequestBody, ContentType) ->
 
 -spec get_url() -> string().
 get_url() ->
-    Port = amoc_config_env:get(api_port, 4000),
+    Port = amoc_config_env:get(amoc, api_port, 4000),
     "http://localhost:" ++ erlang:integer_to_list(Port).

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -1,8 +1,38 @@
 -module(amoc_api_helper).
 
--export([get/1, get/2, put/2, put/3, patch/2, patch/3]).
+-export([get/1, get/2, put/2, put/3, patch/2, patch/3,
+         remove_module/1, module_src/1, module_beam/1,
+         start_amoc/0, stop_amoc/0]).
 
--spec get(string()) -> {integer(), jiffy:jiffy_decode_result()}. 
+-spec start_amoc() -> any().
+start_amoc() ->
+    application:ensure_all_started(amoc).
+
+-spec stop_amoc() -> any().
+stop_amoc() ->
+    application:stop(inets),
+    application:stop(amoc),
+    amoc_api:stop().
+
+-spec remove_module(module()) -> any().
+remove_module(M) ->
+    erlang:delete_module(M),
+    erlang:purge_module(M),
+    ok = file:delete(module_src(M)),
+    ok = file:delete(module_beam(M)).
+
+-spec module_src(module()) -> string().
+module_src(M) ->
+    CodeDir = filename:join(code:priv_dir(amoc), "scenarios"),
+    filename:join([CodeDir, atom_to_list(M) ++ ".erl"]).
+
+-spec module_beam(module()) -> string().
+module_beam(M) ->
+    BeamDir = filename:join(code:priv_dir(amoc), "scenarios_ebin"),
+    filename:join([BeamDir, atom_to_list(M) ++ ".beam"]).
+
+
+-spec get(string()) -> {integer(), jiffy:jiffy_decode_result()}.
 get(Path) -> get(get_url(), Path).
 
 -spec get(string(), string()) -> {integer(), jiffy:jiffy_decode_result()}. 

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -35,8 +35,8 @@ module_beam(M) ->
 -spec get(string()) -> {integer(), jiffy:jiffy_decode_result()}.
 get(Path) -> get(get_url(), Path).
 
--spec get(string(), string()) -> {integer(), jiffy:jiffy_decode_result()}. 
-get(BaseUrl, Path) -> 
+-spec get(string(), string()) -> {integer(), jiffy:jiffy_decode_result()}.
+get(BaseUrl, Path) ->
     request(BaseUrl, erlang:list_to_bitstring(Path), <<"GET">>).
 
 -spec put(string(), binary()) ->
@@ -50,14 +50,14 @@ put(BaseUrl, Path, Body) ->
 
 -spec patch(string(), binary()) ->
     {integer(), jiffy:jiffy_decode_result()}.
-patch(Path, Body) -> patch(get_url(), Path, Body). 
+patch(Path, Body) -> patch(get_url(), Path, Body).
 
 -spec patch(string(), string(), binary()) ->
     {integer(), jiffy:jiffy_decode_result()}.
 patch(BaseUrl, Path, Body) ->
     request(BaseUrl, erlang:list_to_bitstring(Path), <<"PATCH">>, Body).
 
--spec request(string(), binary(), binary()) -> 
+-spec request(string(), binary(), binary()) ->
     {integer(), jiffy:jiffy_decode_result()}.
 request(BaseUrl, Path, Method) -> request(BaseUrl, Path, Method, <<"">>).
 

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -14,17 +14,13 @@ all() ->
      returns_nodes_list_when_amoc_up].
 
 init_per_testcase(_, Config) ->
-    application:ensure_all_started(inets),
+    amoc_api_helper:start_amoc(),
     Config.
 
 end_per_testcase(_, _Config) ->
-    application:stop(inets),
-    application:stop(amoc),
-    amoc_api:stop().
+    amoc_api_helper:stop_amoc().
 
 returns_empty_list_when_amoc_up(_Config) ->
-    %% given
-    given_applications_started(),
     %% when
     {CodeHttp,JSON} = amoc_api_helper:get(?PATH),
     %% then
@@ -34,7 +30,6 @@ returns_empty_list_when_amoc_up(_Config) ->
 
 returns_nodes_list_when_amoc_up(_Config) ->
     %% given
-    given_applications_started(),
     given_prepared_nodes(),
     %% when
     {CodeHttp, JSON} = amoc_api_helper:get(?PATH),
@@ -54,9 +49,6 @@ returns_nodes_list_when_amoc_up(_Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% HELPERS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--spec given_applications_started() -> {ok, [atom()]} | {error, term()}.
-given_applications_started() ->
-    application:ensure_all_started(amoc).
 
 -spec given_prepared_nodes() -> ok.
 given_prepared_nodes() ->

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -22,7 +22,7 @@ end_per_testcase(_, _Config) ->
 
 returns_empty_list_when_amoc_up(_Config) ->
     %% when
-    {CodeHttp,JSON} = amoc_api_helper:get(?PATH),
+    {CodeHttp, JSON} = amoc_api_helper:get(?PATH),
     %% then
     ?assertEqual(200, CodeHttp),
     ThisNode = {atom_to_binary(node(), utf8), <<"up">>},
@@ -45,7 +45,7 @@ returns_nodes_list_when_amoc_up(_Config) ->
         JSON),
     %% cleanup
     clean_nodes().
-    
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% HELPERS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/amoc_api_node_handler_SUITE.erl
+++ b/test/amoc_api_node_handler_SUITE.erl
@@ -52,7 +52,7 @@ returns_nodes_list_when_amoc_up(_Config) ->
 
 -spec given_prepared_nodes() -> ok.
 given_prepared_nodes() ->
-    meck:new(amoc_cluster, [unstick]),
+    meck:new(amoc_cluster, []),
     ConnectionStatus = #{connected => [test1],
                          failed_to_connect => [test2],
                          connection_lost => [test3, test2]},

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -96,7 +96,7 @@ get_scenario_status_returns_loaded_when_scenario_exists_but_not_running(_Config)
 
 patch_scenario_returns_404_when_scenario_not_exists(_Config) ->
     %% given
-    RequestBody = jiffy:encode({[{users,30}]}),
+    RequestBody = jiffy:encode({[{users, 30}]}),
     %% when
     {CodeHttp, _Body} = amoc_api_helper:patch(
                             ?SAMPLE_BAD_SCENARIO_PATH, RequestBody),
@@ -183,7 +183,7 @@ given_test_status_mocked(Value) ->
 -spec mock_amoc_dist_do() -> ok.
 mock_amoc_dist_do() ->
     ok = meck:new(amoc_dist, []),
-    Fun = fun(_,_,_) -> {ok,anything} end,
+    Fun = fun(_, _, _) -> {ok, anything} end,
     ok = meck:expect(amoc_dist, do, Fun).
 
 -spec cleanup_test_status_mock() -> ok.

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -172,7 +172,7 @@ create_env(Config) ->
     {ok, _} = application:ensure_all_started(inets),
     {ok, _} = application:ensure_all_started(amoc),
     ScenarioContent = ?DUMMY_SCENARIO_MODULE(?SAMPLE_SCENARIO_A),
-    ok = amoc_scenario:install_scenario(?SAMPLE_SCENARIO_A,ScenarioContent).
+    ok = amoc_scenario:install_module(?SAMPLE_SCENARIO_A, ScenarioContent).
 
 destroy_env() ->
     ok.

--- a/test/amoc_api_status_handler_SUITE.erl
+++ b/test/amoc_api_status_handler_SUITE.erl
@@ -14,17 +14,13 @@ all() ->
      returns_down_when_api_up_and_amoc_down_online].
 
 init_per_testcase(_, Config) ->
-    application:ensure_all_started(inets),
+    amoc_api_helper:start_amoc(),
     Config.
 
 end_per_testcase(_, _Config) ->
-    application:stop(inets),
-    application:stop(amoc),
-    amoc_api:stop().
+    amoc_api_helper:stop_amoc().
 
 returns_up_when_amoc_up_online(_Config) ->
-    %% given
-    given_applications_started(),
     %% when
     {CodeHttp, Body} = amoc_api_helper:get(?PATH),
     %% then
@@ -33,7 +29,7 @@ returns_up_when_amoc_up_online(_Config) ->
 
 returns_down_when_api_up_and_amoc_down_online(_Config) ->
     %% given
-    given_http_api_started(),
+    given_amoc_app_is_down(),
     %% when
     {CodeHttp, Body} = amoc_api_helper:get(?PATH),
     %% then
@@ -43,10 +39,6 @@ returns_down_when_api_up_and_amoc_down_online(_Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% HELPERS
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--spec given_applications_started() -> {ok, [atom()]} | {error, term()}.
-given_applications_started() ->
-    application:ensure_all_started(amoc).
-
--spec given_http_api_started() -> {ok, pid()}.
-given_http_api_started() ->
-    amoc_api:start().
+-spec given_amoc_app_is_down() -> any().
+given_amoc_app_is_down() ->
+    application:stop(amoc).

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -126,8 +126,8 @@ one_of_function(_) ->
     Param = #{name => var0, description => "var0", default_value => def0,
               verification => OneOf},
     {ok, [#module_parameter{verification_fn = OneOfFN}]} =
-        amoc_config_attributes:process_module_attributes(?MODULE,[Param]),
-    assert_one_of_fn(OneOfFN,OneOf).
+        amoc_config_attributes:process_module_attributes(?MODULE, [Param]),
+    assert_one_of_fn(OneOfFN, OneOf).
 
 assert_one_of_fn(OneOfFN, OneOfValue) ->
     ?assertEqual({arity, 1}, erlang:fun_info(OneOfFN, arity)),

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -8,7 +8,6 @@
 -export([get_module_attributes/1,
          get_module_configuration/1,
          errors_reporting/1,
-         multiple_exports_error/1,
          one_of_function/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -20,39 +19,31 @@
     #{name => var2, description => "var2", default_value => def2, verification => none},
     #{name => var3, description => "var3", default_value => def3,
       verification => [def3, another_atom]},
-    #{name => var4, description => "var4", default_value => def4, verification => is_atom},
-    #{name => var5, description => "var5", default_value => def5,
-      verification => fun ?MODULE:is_atom/1}
+    #{name => var4, description => "var4", default_value => def4,
+      verification => fun ?MODULE:verify_value/1}
 ]).
--required_variable(#{name => var6, description => "var6", default_value => "def6",
-                     verification => is_list, update => read_only}).
--required_variable(#{name => var7, description => "var7", default_value => def7,
+-required_variable(#{name => var5, description => "var5", default_value => def5,
+                     update => read_only}).
+-required_variable(#{name => var6, description => "var6", default_value => def6,
                      verification => none, update => none}).
 -required_variable([
-    #{name => var8, description => "var8", default_value => def8,
-      verification => none, update => update_value},
-    #{name => var9, description => "var9", default_value => def9,
+    #{name => var7, description => "var7", default_value => def7,
       verification => none, update => fun ?MODULE:update_value/2}
 ]).
 
 %% verification functions
--export([is_atom/1, none/1]).
-
+-export([verify_value/1]).
 %% update functions
--export([update_value/2, none/2]).
+-export([update_value/2]).
 
-is_atom(_) -> true.
-none(_) -> true.
-
+verify_value(_) -> true.
 update_value(_, _) -> ok.
-none(_, _) -> ok.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 all() ->
     [get_module_attributes,
      get_module_configuration,
      errors_reporting,
-     multiple_exports_error,
      one_of_function].
 
 get_module_attributes(_) ->
@@ -65,24 +56,19 @@ get_module_attributes(_) ->
         #{name => var3, description => "var3", default_value => def3,
           verification => [def3, another_atom]},
         #{name => var4, description => "var4", default_value => def4,
-          verification => is_atom},
+          verification => fun ?MODULE:verify_value/1},
         #{name => var5, description => "var5", default_value => def5,
-          verification => fun ?MODULE:is_atom/1},
-        #{name => var6, description => "var6", default_value => "def6",
-          verification => is_list, update => read_only},
-        #{name => var7, description => "var7", default_value => def7,
+          update => read_only},
+        #{name => var6, description => "var6", default_value => def6,
           verification => none, update => none},
-        #{name => var8, description => "var8", default_value => def8,
-          verification => none, update => update_value},
-        #{name => var9, description => "var9", default_value => def9,
+        #{name => var7, description => "var7", default_value => def7,
           verification => none, update => fun ?MODULE:update_value/2}],
     ?assertEqual(ExpectedResult, Result).
 
 get_module_configuration(_) ->
-    {ok, Config} = amoc_config_attributes:get_module_configuration(required_variable,
-                                                                   ?MODULE, [erlang]),
-    IsAtomFN = fun ?MODULE:is_atom/1,
-    IsListFN = fun erlang:is_list/1,
+    {ok, Config} =
+        amoc_config_attributes:get_module_configuration(required_variable, ?MODULE),
+    VerifyValueFN = fun ?MODULE:verify_value/1,
     UpdateValueFN = fun ?MODULE:update_value/2,
     UpdateNone = fun amoc_config_attributes:none/2,
     VerificationNone = fun amoc_config_attributes:none/1,
@@ -97,76 +83,50 @@ get_module_configuration(_) ->
                            update_fn = read_only}, %% verification_fn is checked in
                                                    %% 'one_of_function' test case.
          #module_parameter{name = var4, mod = ?MODULE, value = def4,
-                           verification_fn = IsAtomFN, update_fn = read_only},
+                           verification_fn = VerifyValueFN, update_fn = read_only},
          #module_parameter{name = var5, mod = ?MODULE, value = def5,
-                           verification_fn = IsAtomFN, update_fn = read_only},
-         #module_parameter{name = var6, mod = ?MODULE, value = "def6",
-                           verification_fn = IsListFN, update_fn = read_only},
-         #module_parameter{name = var7, mod = ?MODULE, value = def7,
+                           verification_fn = VerificationNone, update_fn = read_only},
+         #module_parameter{name = var6, mod = ?MODULE, value = def6,
                            verification_fn = VerificationNone, update_fn = UpdateNone},
-         #module_parameter{name = var8, mod = ?MODULE, value = def8,
-                           verification_fn = VerificationNone, update_fn = UpdateValueFN},
-         #module_parameter{name = var9, mod = ?MODULE, value = def9,
+         #module_parameter{name = var7, mod = ?MODULE, value = def7,
                            verification_fn = VerificationNone, update_fn = UpdateValueFN}],
         Config).
 
 errors_reporting(_) ->
     InvalidParam0 = #{name => "invalid_var0", description => "var0"},
-    InvalidParam1 = #{name => invalid_var1, description => [$a, <<"b">>]},
+    InvalidParam1 = #{name => invalid_var1, description => [$a, -2]},
     InvalidParam2 = #{name => invalid_var2, description => "var2",
                       verification => <<"invalid_verification_method">>},
     ValidParam3 = #{name => valid_var3, description => "var3", default_value => def3,
                     verification => [def3, another_atom]},
     InvalidParam4 = #{name => invalid_var4, description => "var4",
-                      verification => not_exported_function},
+                      verification => fun erlang:not_exported_function/1},
     InvalidParam5 = #{name => invalid_var5, description => "var5",
-                      update => {invalid_update_method}},
+                      update => invalid_update_method},
     InvalidParam6 = #{name => invalid_var6, description => "var6",
-                      update => not_exported_function},
-    Attributes = [InvalidParam0, InvalidParam1, InvalidParam2,ValidParam3,
-                  InvalidParam4, InvalidParam5,InvalidParam6],
-    AllVerificationModules = [mod1, mod2],
+                      update => fun invalid_module:not_exported_function/2},
+    InvalidParam7 = #{name => invalid_var7, description => "var7",
+                      update => fun update_value/2}, %% local function
+    Attributes = [InvalidParam0, InvalidParam1, InvalidParam2, ValidParam3,
+                  InvalidParam4, InvalidParam5, InvalidParam6, InvalidParam7],
     {error, invalid_attribute_format, Reason} =
-        amoc_config_attributes:process_module_attributes(AllVerificationModules,
-                                                         ?MODULE, Attributes),
+        amoc_config_attributes:process_module_attributes(?MODULE, Attributes),
     ?assertEqual(
         [{InvalidParam0, invalid_attribute},
          {InvalidParam1, invalid_attribute},
          {InvalidParam2, invalid_verification_method},
-         {InvalidParam4, verification_method_not_exported,
-          [?MODULE | AllVerificationModules]},
+         {InvalidParam4, verification_method_not_exported},
          {InvalidParam5, invalid_update_method},
-         {InvalidParam6, update_method_not_exported, [?MODULE | AllVerificationModules]}],
+         {InvalidParam6, update_method_not_exported},
+         {InvalidParam7, update_method_not_exported}],
         Reason).
-
-multiple_exports_error(_)->
-    Module = ct, %% use some dummy module that belongs to some application
-    {ok, App} = application:get_application(Module),
-    Param = #{name => var0, description => "var0", verification => add},
-    AllVerificationModules = [amoc, amoc_dist],
-    [code:ensure_loaded(Module) || Module <- AllVerificationModules],
-    {error, invalid_attribute_format, Reason} =
-        amoc_config_attributes:process_module_attributes(
-            AllVerificationModules, Module, [Param]),
-    ?assertEqual(
-        [{Param, multiple_functions_found, [fun amoc_dist:add/1, fun amoc:add/1]}],
-        Reason),
-    %% now try to set 'config_verification_modules' env variable for App
-    amoc_config_helper:set_app_env(App, config_verification_modules, [amoc, amoc]),
-    {ok, Result} = amoc_config_attributes:process_module_attributes(
-                       AllVerificationModules, Module, [Param]),
-    ?assertEqual(
-        [#module_parameter{name = var0, mod = ct, value = undefined,
-                           verification_fn = fun amoc:add/1, update_fn = read_only}],
-        Result),
-    amoc_config_helper:unset_app_env(App, config_verification_modules).
 
 one_of_function(_) ->
     OneOf = [def3, another_atom],
     Param = #{name => var0, description => "var0", default_value => def0,
               verification => OneOf},
     {ok, [#module_parameter{verification_fn = OneOfFN}]} =
-        amoc_config_attributes:process_module_attributes([],?MODULE,[Param]),
+        amoc_config_attributes:process_module_attributes(?MODULE,[Param]),
     assert_one_of_fn(OneOfFN,OneOf).
 
 assert_one_of_fn(OneOfFN, OneOfValue) ->

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -1,0 +1,85 @@
+
+-module(amoc_config_attributes_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0]).
+-export([get_module_attributes/1,
+         get_module_configuration/1,
+         errors_reporting/1]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% these attributes and functions are required for the testing purposes %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-required_variable({var0, "var0"}).
+-required_variable({var1, "var1", def1}).
+-required_variable([
+    {var2, "var2", def2, none},
+    {var3, "var3", def3, [def3, another_atom]},
+    {var4, "var4", def4, is_atom},
+    {var5, "var5", def5, fun ?MODULE:is_atom/1}
+]).
+-required_variable({var6, "var6", "def6", is_list}).
+
+%% verification functions
+-export([is_atom/1, none/1]).
+
+is_atom(_) -> true.
+none(_) -> true.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+all() ->
+    [get_module_attributes,
+     get_module_configuration,
+     errors_reporting].
+
+get_module_attributes(_) ->
+    Result = amoc_config_attributes:get_module_attributes(required_variable, ?MODULE),
+    ExpectedResult = [{var0, "var0"},
+                      {var1, "var1", def1},
+                      {var2, "var2", def2, none},
+                      {var3, "var3", def3, [def3, another_atom]},
+                      {var4, "var4", def4, is_atom},
+                      {var5, "var5", def5, fun ?MODULE:is_atom/1},
+                      {var6, "var6", "def6", is_list}],
+    ?assertEqual(ExpectedResult, Result).
+
+get_module_configuration(_) ->
+    {ok, Config} = amoc_config_attributes:get_module_configuration(required_variable,
+                                                                   ?MODULE, [erlang]),
+    IsAtomFN = fun ?MODULE:is_atom/1,
+    IsListFN = fun erlang:is_list/1,
+    ?assertMatch(
+        [{var0, ?MODULE, undefined, _},
+         {var1, ?MODULE, def1, _},
+         {var2, ?MODULE, def2, _},
+         {var3, ?MODULE, def3, _},
+         {var4, ?MODULE, def4, IsAtomFN},
+         {var5, ?MODULE, def5, IsAtomFN},
+         {var6, ?MODULE, "def6", IsListFN}],
+        Config),
+    [assert_fn(FN, amoc_config_attributes, 1) || {_, _, _, FN, _} <- Config,
+                                                 FN =/= IsAtomFN, FN =/= IsListFN].
+
+assert_fn(FN, Module, Arity) ->
+    ?assertEqual({arity, Arity}, erlang:fun_info(FN, arity)),
+    ?assertEqual({module, Module}, erlang:fun_info(FN, module)).
+
+errors_reporting(_) ->
+    Attributes = [
+        {"invalid_var0", "var0"},
+        {invalid_var1, <<"var1">>, def1},
+        {invalid_var2, "var2", def2, <<"invalid_verification_method">>},
+        {valid_var3, "var3", def3, [def3, another_atom]},
+        {invalid_var4, "var4", def4, not_exported_function}],
+    {error, invalid_attribute_format, Reason} =
+        amoc_config_attributes:process_module_attributes([?MODULE], ?MODULE, Attributes),
+    ?assertEqual(
+        [{invalid_attribute, {"invalid_var0", "var0"}},
+         {invalid_attribute, {invalid_var1, <<"var1">>, def1}},
+         {invalid_verification_method,
+            {invalid_var2, ?MODULE, def2, <<"invalid_verification_method">>}},
+         {verification_method_not_exported,
+            {invalid_var4, ?MODULE, def4, not_exported_function},
+            [?MODULE]}],
+        Reason).

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -8,7 +8,9 @@
 -export([get_module_attributes/1,
          get_module_configuration/1,
          errors_reporting/1,
-         multiple_exports_error/1]).
+         multiple_exports_error/1,
+         old_attributes_format/1,
+         one_of_function/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% these attributes and functions are required for the testing purposes %%
@@ -51,7 +53,9 @@ all() ->
     [get_module_attributes,
      get_module_configuration,
      errors_reporting,
-     multiple_exports_error].
+     multiple_exports_error,
+     old_attributes_format,
+     one_of_function].
 
 get_module_attributes(_) ->
     Result = amoc_config_attributes:get_module_attributes(required_variable, ?MODULE),
@@ -80,37 +84,31 @@ get_module_configuration(_) ->
     IsAtomFN = fun ?MODULE:is_atom/1,
     IsListFN = fun erlang:is_list/1,
     UpdateValueFN = fun ?MODULE:update_value/2,
+    UpdateNone = fun amoc_config_attributes:none/2,
+    VerificationNone = fun amoc_config_attributes:none/1,
     ?assertMatch(
         [#module_parameter{name = var0, mod = ?MODULE, value = undefined,
-                           update_fn = read_only},
+                           verification_fn = VerificationNone, update_fn = read_only},
          #module_parameter{name = var1, mod = ?MODULE, value = def1,
-                           update_fn = read_only},
+                           verification_fn = VerificationNone, update_fn = read_only},
          #module_parameter{name = var2, mod = ?MODULE, value = def2,
-                           update_fn = read_only},
+                           verification_fn = VerificationNone, update_fn = read_only},
          #module_parameter{name = var3, mod = ?MODULE, value = def3,
-                           update_fn = read_only},
+                           update_fn = read_only}, %% verification_fn is checked in
+                                                   %% 'one_of_function' test case.
          #module_parameter{name = var4, mod = ?MODULE, value = def4,
                            verification_fn = IsAtomFN, update_fn = read_only},
          #module_parameter{name = var5, mod = ?MODULE, value = def5,
                            verification_fn = IsAtomFN, update_fn = read_only},
          #module_parameter{name = var6, mod = ?MODULE, value = "def6",
                            verification_fn = IsListFN, update_fn = read_only},
-         #module_parameter{name = var7, mod = ?MODULE, value = def7},
+         #module_parameter{name = var7, mod = ?MODULE, value = def7,
+                           verification_fn = VerificationNone, update_fn = UpdateNone},
          #module_parameter{name = var8, mod = ?MODULE, value = def8,
-                           update_fn = UpdateValueFN},
+                           verification_fn = VerificationNone, update_fn = UpdateValueFN},
          #module_parameter{name = var9, mod = ?MODULE, value = def9,
-                           update_fn = UpdateValueFN}],
-        Config),
-    [assert_fn(FN, amoc_config_attributes, 1)
-     || #module_parameter{verification_fn = FN} <- Config,
-        FN =/= IsAtomFN, FN =/= IsListFN],
-    [assert_fn(FN, amoc_config_attributes, 2)
-     || #module_parameter{update_fn = FN} <- Config,
-        FN =/= UpdateValueFN, FN =/= read_only].
-
-assert_fn(FN, Module, Arity) ->
-    ?assertEqual({arity, Arity}, erlang:fun_info(FN, arity)),
-    ?assertEqual({module, Module}, erlang:fun_info(FN, module)).
+                           verification_fn = VerificationNone, update_fn = UpdateValueFN}],
+        Config).
 
 errors_reporting(_) ->
     InvalidParam0 = #{name => "invalid_var0", description => "var0"},
@@ -127,36 +125,75 @@ errors_reporting(_) ->
                       update => not_exported_function},
     Attributes = [InvalidParam0, InvalidParam1, InvalidParam2,ValidParam3,
                   InvalidParam4, InvalidParam5,InvalidParam6],
+    AllVerificationModules = [mod1, mod2],
     {error, invalid_attribute_format, Reason} =
-        amoc_config_attributes:process_module_attributes([mod1, mod2], ?MODULE, Attributes),
+        amoc_config_attributes:process_module_attributes(AllVerificationModules,
+                                                         ?MODULE, Attributes),
     ?assertEqual(
-        [{invalid_attribute, InvalidParam0},
-         {invalid_attribute, InvalidParam1},
-         {invalid_verification_method, InvalidParam2},
-         {verification_method_not_exported, InvalidParam4, [?MODULE, mod1, mod2]},
-         {invalid_update_method, InvalidParam5},
-         {update_method_not_exported, InvalidParam6, [?MODULE, mod1, mod2]}],
+        [{InvalidParam0, invalid_attribute},
+         {InvalidParam1, invalid_attribute},
+         {InvalidParam2, invalid_verification_method},
+         {InvalidParam4, verification_method_not_exported,
+          [?MODULE | AllVerificationModules]},
+         {InvalidParam5, invalid_update_method},
+         {InvalidParam6, update_method_not_exported, [?MODULE | AllVerificationModules]}],
         Reason).
 
 multiple_exports_error(_)->
     Module = ct, %% use some dummy module that belongs to some application
     {ok, App} = application:get_application(Module),
-    Param = #{name => var0, description => "var0", verification=>add},
+    Param = #{name => var0, description => "var0", verification => add},
     AllVerificationModules = [amoc, amoc_dist],
     [code:ensure_loaded(Module) || Module <- AllVerificationModules],
     {error, invalid_attribute_format, Reason} =
         amoc_config_attributes:process_module_attributes(
             AllVerificationModules, Module, [Param]),
     ?assertEqual(
-        [{multiple_functions_found,
-          [fun amoc_dist:add/1, fun amoc:add/1],
-          #{description => "var0", name => var0, verification => add}}],
+        [{Param, multiple_functions_found, [fun amoc_dist:add/1, fun amoc:add/1]}],
         Reason),
     %% now try to set 'config_verification_modules' env variable for App
     amoc_config_helper:set_app_env(App, config_verification_modules, [amoc, amoc]),
     {ok, Result} = amoc_config_attributes:process_module_attributes(
                        AllVerificationModules, Module, [Param]),
     ?assertEqual(
-        [{module_parameter, var0, ct, undefined, fun amoc:add/1, read_only}],
+        [#module_parameter{name = var0, mod = ct, value = undefined,
+                           verification_fn = fun amoc:add/1, update_fn = read_only}],
         Result),
     amoc_config_helper:unset_app_env(App, config_verification_modules).
+
+old_attributes_format(_) ->
+    Param0 = {var0, "var0"},
+    Param1 = {var1, <<"var1">>, "def1"},
+    Param2 = {var2, <<"var1"/utf8>>, def2, is_atom},
+    Attributes = [Param0, Param1, Param2],
+    {ok, Result} = amoc_config_attributes:process_module_attributes([], ?MODULE,
+                                                                    Attributes),
+    VerificationNone = fun amoc_config_attributes:none/1,
+    ?assertEqual(
+        [#module_parameter{name = var0, mod = ?MODULE, value = undefined,
+                           verification_fn = VerificationNone, update_fn = read_only},
+         #module_parameter{name = var1, mod = ?MODULE, value = "def1",
+                           verification_fn = VerificationNone, update_fn = read_only},
+         #module_parameter{name = var2, mod = ?MODULE, value = def2,
+                           verification_fn = fun ?MODULE:is_atom/1, update_fn = read_only}],
+        Result),
+
+    InvalidDescription = [-1],
+    InvalidParam = {invalid_param,InvalidDescription},
+    {error,invalid_attribute_format, Reason} =
+        amoc_config_attributes:process_module_attributes([], ?MODULE, [InvalidParam]),
+    ?assertEqual([{InvalidParam, invalid_attribute}], Reason).
+
+one_of_function(_) ->
+    OneOf = [def3, another_atom],
+    Param = #{name => var0, description => "var0", value => def0,
+              verification => OneOf},
+    {ok, [#module_parameter{verification_fn = OneOfFN}]} =
+        amoc_config_attributes:process_module_attributes([],?MODULE,[Param]),
+    assert_one_of_fn(OneOfFN,OneOf).
+
+assert_one_of_fn(OneOfFN, OneOfValue) ->
+    ?assertEqual({arity, 1}, erlang:fun_info(OneOfFN, arity)),
+    ?assertEqual({module, amoc_config_attributes}, erlang:fun_info(OneOfFN, module)),
+    ?assertEqual({type, local}, erlang:fun_info(OneOfFN, type)),
+    ?assertEqual({env, [OneOfValue]}, erlang:fun_info(OneOfFN, env)).

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -9,7 +9,6 @@
          get_module_configuration/1,
          errors_reporting/1,
          multiple_exports_error/1,
-         old_attributes_format/1,
          one_of_function/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -54,7 +53,6 @@ all() ->
      get_module_configuration,
      errors_reporting,
      multiple_exports_error,
-     old_attributes_format,
      one_of_function].
 
 get_module_attributes(_) ->
@@ -162,29 +160,6 @@ multiple_exports_error(_)->
                            verification_fn = fun amoc:add/1, update_fn = read_only}],
         Result),
     amoc_config_helper:unset_app_env(App, config_verification_modules).
-
-old_attributes_format(_) ->
-    Param0 = {var0, "var0"},
-    Param1 = {var1, <<"var1">>, "def1"},
-    Param2 = {var2, <<"var1"/utf8>>, def2, is_atom},
-    Attributes = [Param0, Param1, Param2],
-    {ok, Result} = amoc_config_attributes:process_module_attributes([], ?MODULE,
-                                                                    Attributes),
-    VerificationNone = fun amoc_config_attributes:none/1,
-    ?assertEqual(
-        [#module_parameter{name = var0, mod = ?MODULE, value = undefined,
-                           verification_fn = VerificationNone, update_fn = read_only},
-         #module_parameter{name = var1, mod = ?MODULE, value = "def1",
-                           verification_fn = VerificationNone, update_fn = read_only},
-         #module_parameter{name = var2, mod = ?MODULE, value = def2,
-                           verification_fn = fun ?MODULE:is_atom/1, update_fn = read_only}],
-        Result),
-
-    InvalidDescription = [-1],
-    InvalidParam = {invalid_param,InvalidDescription},
-    {error,invalid_attribute_format, Reason} =
-        amoc_config_attributes:process_module_attributes([], ?MODULE, [InvalidParam]),
-    ?assertEqual([{InvalidParam, invalid_attribute}], Reason).
 
 one_of_function(_) ->
     OneOf = [def3, another_atom],

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -16,23 +16,23 @@
 %% these attributes and functions are required for the testing purposes %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -required_variable(#{name => var0, description => "var0"}).
--required_variable(#{name => var1, description => "var1", value => def1}).
+-required_variable(#{name => var1, description => "var1", default_value => def1}).
 -required_variable([
-    #{name => var2, description => "var2", value => def2, verification => none},
-    #{name => var3, description => "var3", value => def3,
+    #{name => var2, description => "var2", default_value => def2, verification => none},
+    #{name => var3, description => "var3", default_value => def3,
       verification => [def3, another_atom]},
-    #{name => var4, description => "var4", value => def4, verification => is_atom},
-    #{name => var5, description => "var5", value => def5,
+    #{name => var4, description => "var4", default_value => def4, verification => is_atom},
+    #{name => var5, description => "var5", default_value => def5,
       verification => fun ?MODULE:is_atom/1}
 ]).
--required_variable(#{name => var6, description => "var6", value => "def6",
+-required_variable(#{name => var6, description => "var6", default_value => "def6",
                      verification => is_list, update => read_only}).
--required_variable(#{name => var7, description => "var7", value => def7,
+-required_variable(#{name => var7, description => "var7", default_value => def7,
                      verification => none, update => none}).
 -required_variable([
-    #{name => var8, description => "var8", value => def8,
+    #{name => var8, description => "var8", default_value => def8,
       verification => none, update => update_value},
-    #{name => var9, description => "var9", value => def9,
+    #{name => var9, description => "var9", default_value => def9,
       verification => none, update => fun ?MODULE:update_value/2}
 ]).
 
@@ -61,20 +61,22 @@ get_module_attributes(_) ->
     Result = amoc_config_attributes:get_module_attributes(required_variable, ?MODULE),
     ExpectedResult = [
         #{name => var0, description => "var0"},
-        #{name => var1, description => "var1", value => def1},
-        #{name => var2, description => "var2", value => def2, verification => none},
-        #{name => var3, description => "var3", value => def3,
+        #{name => var1, description => "var1", default_value => def1},
+        #{name => var2, description => "var2", default_value => def2,
+          verification => none},
+        #{name => var3, description => "var3", default_value => def3,
           verification => [def3, another_atom]},
-        #{name => var4, description => "var4", value => def4, verification => is_atom},
-        #{name => var5, description => "var5", value => def5,
+        #{name => var4, description => "var4", default_value => def4,
+          verification => is_atom},
+        #{name => var5, description => "var5", default_value => def5,
           verification => fun ?MODULE:is_atom/1},
-        #{name => var6, description => "var6", value => "def6",
+        #{name => var6, description => "var6", default_value => "def6",
           verification => is_list, update => read_only},
-        #{name => var7, description => "var7", value => def7,
+        #{name => var7, description => "var7", default_value => def7,
           verification => none, update => none},
-        #{name => var8, description => "var8", value => def8,
+        #{name => var8, description => "var8", default_value => def8,
           verification => none, update => update_value},
-        #{name => var9, description => "var9", value => def9,
+        #{name => var9, description => "var9", default_value => def9,
           verification => none, update => fun ?MODULE:update_value/2}],
     ?assertEqual(ExpectedResult, Result).
 
@@ -115,7 +117,7 @@ errors_reporting(_) ->
     InvalidParam1 = #{name => invalid_var1, description => [$a, <<"b">>]},
     InvalidParam2 = #{name => invalid_var2, description => "var2",
                       verification => <<"invalid_verification_method">>},
-    ValidParam3 = #{name => valid_var3, description => "var3", value => def3,
+    ValidParam3 = #{name => valid_var3, description => "var3", default_value => def3,
                     verification => [def3, another_atom]},
     InvalidParam4 = #{name => invalid_var4, description => "var4",
                       verification => not_exported_function},
@@ -186,7 +188,7 @@ old_attributes_format(_) ->
 
 one_of_function(_) ->
     OneOf = [def3, another_atom],
-    Param = #{name => var0, description => "var0", value => def0,
+    Param = #{name => var0, description => "var0", default_value => def0,
               verification => OneOf},
     {ok, [#module_parameter{verification_fn = OneOfFN}]} =
         amoc_config_attributes:process_module_attributes([],?MODULE,[Param]),

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -26,7 +26,7 @@ parse_value_prop_test(_) ->
                                   {10, any()}]),
     ProperTest = ?FORALL(Value, RealAnyType,
                          amoc_config_env:parse_value(format_value(Value)) =:= {ok, Value}),
-    ?assertEqual(true, proper:quickcheck(ProperTest,[quiet])).
+    ?assertEqual(true, proper:quickcheck(ProperTest, [quiet])).
 
 config_os_env_test(_) ->
     ?assertEqual(undefined, get_env(?APP, some_variable)),

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -3,20 +3,23 @@
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-import(amoc_config_helper, [format_value/1,
+                             get_env/2,
+                             get_env/3,
+                             set_os_env/2,
+                             unset_os_env/1,
+                             set_app_env/3,
+                             unset_app_env/2]).
+
 -compile(export_all).
+
+-define(APP, common_test).
 
 all() ->
     [parse_value_prop_test,
      config_os_env_test,
      config_app_env_test,
      config_os_env_shadows_app_env_test].
-
-init_per_suite(Config) ->
-    {ok, _} = application:ensure_all_started(amoc),
-    Config.
-
-end_per_suite(Config) ->
-    Config.
 
 parse_value_prop_test(_) ->
     RealAnyType = weighted_union([{1, map(any(), any())},
@@ -25,70 +28,44 @@ parse_value_prop_test(_) ->
                          amoc_config_env:parse_value(format_value(Value)) =:= {ok, Value}),
     ?assertEqual(true, proper:quickcheck(ProperTest,[quiet])).
 
-
 config_os_env_test(_) ->
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)),
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
     set_os_env(some_variable, some_value),
-    ?assertEqual(some_value, get_env(some_variable)),
-    ?assertEqual(some_value, get_env(some_variable, default_value)),
+    ?assertEqual(some_value, get_env(?APP, some_variable)),
+    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
     set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(some_variable)),
-    ?assertEqual(another_value, get_env(some_variable, default_value)),
+    ?assertEqual(another_value, get_env(?APP, some_variable)),
+    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
     unset_os_env(some_variable),
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)).
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).
 
 config_app_env_test(_) ->
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)),
-    set_app_env(some_variable, some_value),
-    ?assertEqual(some_value, get_env(some_variable)),
-    ?assertEqual(some_value, get_env(some_variable, default_value)),
-    set_app_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(some_variable)),
-    ?assertEqual(another_value, get_env(some_variable, default_value)),
-    unset_app_env(some_variable),
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)).
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
+    set_app_env(?APP, some_variable, some_value),
+    ?assertEqual(some_value, get_env(?APP, some_variable)),
+    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
+    set_app_env(?APP, some_variable, another_value),
+    ?assertEqual(another_value, get_env(?APP, some_variable)),
+    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
+    unset_app_env(?APP, some_variable),
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).
 
 config_os_env_shadows_app_env_test(_) ->
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)),
-    set_app_env(some_variable, some_value),
-    ?assertEqual(some_value, get_env(some_variable)),
-    ?assertEqual(some_value, get_env(some_variable, default_value)),
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
+    set_app_env(?APP, some_variable, some_value),
+    ?assertEqual(some_value, get_env(?APP, some_variable)),
+    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
     set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(some_variable)),
-    ?assertEqual(another_value, get_env(some_variable, default_value)),
+    ?assertEqual(another_value, get_env(?APP, some_variable)),
+    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
     unset_os_env(some_variable),
-    ?assertEqual(some_value, get_env(some_variable)),
-    ?assertEqual(some_value, get_env(some_variable, default_value)),
-    unset_app_env(some_variable),
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)).
-
-
-set_app_env(Name, Value) ->
-    application:set_env(amoc, Name, Value).
-
-unset_app_env(Name) ->
-    application:unset_env(amoc, Name).
-
-set_os_env(Name, Value) ->
-    os:putenv(env_name(Name), format_value(Value)).
-
-unset_os_env(Name) ->
-    os:unsetenv(env_name(Name)).
-
-env_name(Name) ->
-    "AMOC_" ++ string:uppercase(erlang:atom_to_list(Name)).
-
-get_env(Name) ->
-    amoc_config_env:get(amoc, Name).
-
-get_env(Name, Default) ->
-    amoc_config_env:get(amoc, Name, Default).
-
-format_value(Value) ->
-    lists:flatten(io_lib:format("~tp", [Value])).
+    ?assertEqual(some_value, get_env(?APP, some_variable)),
+    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
+    unset_app_env(?APP, some_variable),
+    ?assertEqual(undefined, get_env(?APP, some_variable)),
+    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -27,46 +27,46 @@ parse_value_prop_test(_) ->
 
 
 config_os_env_test(_) ->
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)),
     set_os_env(some_variable, some_value),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(some_value, get_env(some_variable)),
+    ?assertEqual(some_value, get_env(some_variable, default_value)),
     set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(another_value, get_env(some_variable)),
+    ?assertEqual(another_value, get_env(some_variable, default_value)),
     unset_os_env(some_variable),
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)).
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)).
 
 config_app_env_test(_) ->
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)),
     set_app_env(some_variable, some_value),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(some_value, get_env(some_variable)),
+    ?assertEqual(some_value, get_env(some_variable, default_value)),
     set_app_env(some_variable, another_value),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(another_value, get_env(some_variable)),
+    ?assertEqual(another_value, get_env(some_variable, default_value)),
     unset_app_env(some_variable),
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)).
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)).
 
 config_os_env_shadows_app_env_test(_) ->
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)),
     set_app_env(some_variable, some_value),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(some_value, get_env(some_variable)),
+    ?assertEqual(some_value, get_env(some_variable, default_value)),
     set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(another_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(another_value, get_env(some_variable)),
+    ?assertEqual(another_value, get_env(some_variable, default_value)),
     unset_os_env(some_variable),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable)),
-    ?assertEqual(some_value, amoc_config_env:get(some_variable, default_value)),
+    ?assertEqual(some_value, get_env(some_variable)),
+    ?assertEqual(some_value, get_env(some_variable, default_value)),
     unset_app_env(some_variable),
-    ?assertEqual(undefined, amoc_config_env:get(some_variable)),
-    ?assertEqual(default_value, amoc_config_env:get(some_variable, default_value)).
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)).
 
 
 set_app_env(Name, Value) ->
@@ -83,6 +83,12 @@ unset_os_env(Name) ->
 
 env_name(Name) ->
     "AMOC_" ++ string:uppercase(erlang:atom_to_list(Name)).
+
+get_env(Name) ->
+    amoc_config_env:get(amoc, Name).
+
+get_env(Name, Default) ->
+    amoc_config_env:get(amoc, Name, Default).
 
 format_value(Value) ->
     lists:flatten(io_lib:format("~tp", [Value])).

--- a/test/amoc_config_helper.erl
+++ b/test/amoc_config_helper.erl
@@ -1,0 +1,27 @@
+-module(amoc_config_helper).
+
+-compile(export_all).
+
+set_app_env(App, Name, Value) ->
+    application:set_env(App, Name, Value).
+
+unset_app_env(App, Name) ->
+    application:unset_env(App, Name).
+
+set_os_env(Name, Value) ->
+    os:putenv(env_name(Name), format_value(Value)).
+
+unset_os_env(Name) ->
+    os:unsetenv(env_name(Name)).
+
+env_name(Name) ->
+    "AMOC_" ++ string:uppercase(erlang:atom_to_list(Name)).
+
+get_env(App, Name) ->
+    amoc_config_env:get(App, Name).
+
+get_env(App, Name, Default) ->
+    amoc_config_env:get(App, Name, Default).
+
+format_value(Value) ->
+    lists:flatten(io_lib:format("~tp", [Value])).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -50,7 +50,7 @@ end_per_group(update_settings,Config) ->
 
 parse_scenario_settings(_) ->
     mock_ets_tables(),
-    ets:insert(amoc_scenarios, {amoc_controller, parametrised}),
+    ets:insert(amoc_scenarios, {amoc_controller, configurable}),
     ScenarioSettings = [{interarrival, 500},
                         {var1, def1}],
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
@@ -65,7 +65,7 @@ parse_scenario_settings(_) ->
     ?assertEqual(def1, amoc_config:get(var1, some_value)),
     %% overwritten variable
     ?assertEqual(val2, amoc_config:get(var2)),
-    %% parametrised module variable (defined in amoc_controller)
+    %% configurable module variable (defined in amoc_controller)
     ?assertEqual(500, amoc_config:get(interarrival)).
 
 update_settings(_) ->
@@ -131,7 +131,7 @@ update_settings_undef_param(_) ->
 
 implicit_variable_redefinition(_) ->
     mock_ets_tables(),
-    ets:insert(amoc_scenarios, {?MODULE, parametrised}),
+    ets:insert(amoc_scenarios, {?MODULE, configurable}),
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
     ?assertEqual({error, parameter_overriding, {var0, ?MODULE, ?MODULE}}, Ret).
 

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -39,12 +39,12 @@ groups() ->
                             update_settings_invalid_value,
                             update_settings_undef_param]}].
 
-init_per_group(update_settings,Config) ->
+init_per_group(update_settings, Config) ->
     meck:new(?MOCK_MOD, [non_strict, no_link]),
     meck:expect(?MOCK_MOD, update, ['_', '_'], ok),
     Config.
 
-end_per_group(update_settings,Config) ->
+end_per_group(update_settings, Config) ->
     meck:unload(),
     Config.
 
@@ -99,7 +99,7 @@ update_settings_readonly(_) ->
                   [{var0, ?MODULE},
                    {var1, ?MODULE}]},
                  ReadOnlyRet),
-    isEqualList(Table, ets:tab2list(amoc_config)),
+    is_equal_list(Table, ets:tab2list(amoc_config)),
     ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
 
 update_settings_invalid_value(_) ->
@@ -114,7 +114,7 @@ update_settings_invalid_value(_) ->
                   [{var2, invalid_val2,
                     {verification_failed, {not_one_of, [def2, val2]}}}]},
                  InvalidValueRet),
-    isEqualList(Table, ets:tab2list(amoc_config)),
+    is_equal_list(Table, ets:tab2list(amoc_config)),
     ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
 
 update_settings_undef_param(_) ->
@@ -126,7 +126,7 @@ update_settings_undef_param(_) ->
                          {invalid_var2, val2}],
     UndefParamRet = amoc_config_scenario:update_settings(ScenarioSettings3),
     ?assertEqual({error, undefined_parameters, [invalid_var2]}, UndefParamRet),
-    isEqualList(Table, ets:tab2list(amoc_config)),
+    is_equal_list(Table, ets:tab2list(amoc_config)),
     ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
 
 implicit_variable_redefinition(_) ->
@@ -179,5 +179,5 @@ mock_ets_tables() ->
     amoc_scenarios = ets:new(amoc_scenarios, EtsOptions),
     amoc_config_utils:create_amoc_config_ets().
 
-isEqualList(List1, List2) ->
+is_equal_list(List1, List2) ->
     ?assertEqual(lists:sort(List1), lists:sort(List2)).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -14,10 +14,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 -required_variable(#{name => var0, description => "var0"}).
 -required_variable(#{name => var1, description => "var1"}).
--required_variable(#{name => var2, description => "var2", value => def2}).
--override_variable(#{name => var2, description => "var2", value => val2,
+-required_variable(#{name => var2, description => "var2", default_value => def2}).
+-override_variable(#{name => var2, description => "var2", default_value => val2,
                      verification => [def2, val2], update => update_fn}).
--override_variable(#{name => var3, description => "var3", value => def3,
+-override_variable(#{name => var3, description => "var3", default_value => def3,
                      update => update_fn}).
 
 update_fn(Name, Value) -> apply(?MOCK_MOD, update, [Name, Value]).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -13,13 +13,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% these attributes are required for the testing purposes %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--required_variable({var0, "var0"}).
--required_variable({var1, "var1"}).
--required_variable({var2, "var2", def2}).
--override_variable({var2, "var2", val2, [def2, val2], update}).
--override_variable({var3, "var3", def3, none, update}).
+-required_variable(#{name => var0, description => "var0"}).
+-required_variable(#{name => var1, description => "var1"}).
+-required_variable(#{name => var2, description => "var2", value => def2}).
+-override_variable(#{name => var2, description => "var2", value => val2,
+                     verification => [def2, val2], update => update_fn}).
+-override_variable(#{name => var3, description => "var3", value => def3,
+                     update => update_fn}).
 
-update(Name, Value) -> apply(?MOCK_MOD, update, [Name, Value]).
+update_fn(Name, Value) -> apply(?MOCK_MOD, update, [Name, Value]).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -179,8 +179,8 @@ invalid_module_attributes(_) ->
 
 mock_ets_tables() ->
     EtsOptions = [named_table, protected, {read_concurrency, true}],
-    amoc_config = ets:new(amoc_config, EtsOptions),
-    amoc_scenarios = ets:new(amoc_scenarios, EtsOptions).
+    amoc_scenarios = ets:new(amoc_scenarios, EtsOptions),
+    amoc_config_utils:create_amoc_config_ets().
 
 isEqualList(List1, List2) ->
     ?assertEqual(lists:sort(List1), lists:sort(List2)).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -4,162 +4,93 @@
 
 -compile(export_all).
 
+-import(amoc_config_helper, [set_app_env/3,
+                             unset_app_env/2]).
+-define(APP, common_test).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% these attributes are required for the testing purposes %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--behaviour(amoc_scenario).
+-required_variable({var0, "var0"}).
 -required_variable({var1, "var1"}).
 -required_variable({var2, "var2", def2}).
--required_variable([
-    {var3, "var3", 3, positive_integer},
-    {var4, "var4", def4, [def4, another_atom]},
-    {var5, "var5", def5, test_verification_function},
-    {var6, "var6", def6, fun ?MODULE:test_verification_function/1}
-]).
-
--export([init/0, test_verification_function/1, positive_integer/1]).
-test_verification_function(_) -> true.
-positive_integer(I) -> is_integer(I) andalso I > 0.
-
-init() -> ok.
+-override_variable({var2, "var2", val2, [def2, val2]}).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+
 all() ->
-    [init_scenario,
-     get_module_attributes,
-     process_scenario_config_uses_default_values,
-     process_scenario_config_shadows_default_values,
-     process_scenario_config_returns_error_for_invalid_values,
-     process_scenario_config_returns_preprocessed_value].
+    [parse_scenario_settings,
+     implicit_variable_redefinition,
+     invalid_verification_module,
+     invalid_parametrised_module,
+     invalid_module_attributes,
+     invalid_value].
 
-init_per_suite(Config) ->
-    {ok, _} = application:ensure_all_started(amoc),
-    meck:new(verification_module, [non_strict, no_link]),
-    meck:expect(verification_module, positive_integer,
-                fun(I) -> is_integer(I) andalso I > 0 end),
-    meck:expect(verification_module, nonnegative_integer,
-                fun(I) -> is_integer(I) andalso I >= 0 end),
-    meck:expect(verification_module, binary,
-                fun(Binary) -> is_binary(Binary) end),
-    set_env(config_verification_modulesv, [verification_module]),
-    Config.
-
-end_per_suite(Config) ->
-    meck:unload(),
-    unset_env(config_verification_modulesv),
-    Config.
-
-init_scenario(_) ->
-    ScenarioConfig = [{var0, def0}, {var5, val5}],
-    ?assertMatch(ok, amoc_controller:start_scenario(?MODULE, ScenarioConfig)),
-    ?assertEqual(undefined, amoc_config:get(var00)),
-    ?assertEqual(def00, amoc_config:get(var00, def00)),
+parse_scenario_settings(_) ->
+    mock_ets_tables(),
+    ets:insert(amoc_scenarios, {amoc_controller, parametrised}),
+    ScenarioSettings = [{undefined_var, some_value},
+                        {interarrival, 500},
+                        {var1, def1}],
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
+    ?assertEqual(ok, Ret),
+    %% undefined variable provided in settings
+    ?assertThrow({invalid_setting, undefined_var}, amoc_config:get(undefined_var)),
+    %% undefined variable
+    ?assertThrow({invalid_setting, another_undefined_var},
+                 amoc_config:get(another_undefined_var)),
+    %% undefined value
     ?assertEqual(undefined, amoc_config:get(var0)),
-    ?assertEqual(def0, amoc_config:get(var0, def0)),
-    ?assertEqual(undefined, amoc_config:get(var1)),
-    ?assertEqual(def1, amoc_config:get(var1, def1)),
-    ?assertEqual(def2, amoc_config:get(var2)),
-    ?assertEqual(def2, amoc_config:get(var2, some_atom)),
-    ?assertEqual(val5, amoc_config:get(var5)),
-    ?assertEqual(val5, amoc_config:get(var5, some_atom)).
+    ?assertEqual(some_value, amoc_config:get(var0, some_value)),
+    %% defined (in settings) value
+    ?assertEqual(def1, amoc_config:get(var1)),
+    ?assertEqual(def1, amoc_config:get(var1, some_value)),
+    %% overwritten variable
+    ?assertEqual(val2, amoc_config:get(var2)),
+    %% parametrised module variable (defined in amoc_controller)
+    ?assertEqual(500, amoc_config:get(interarrival)).
 
-get_module_attributes(_) ->
-    Result = amoc_config_scenario:get_module_attributes(?MODULE),
-    ExpectedResult = [{var1, "var1"},
-                      {var2, "var2", def2},
-                      {var3, "var3", 3, positive_integer},
-                      {var4, "var4", def4, [def4, another_atom]},
-                      {var5, "var5", def5, test_verification_function},
-                      {var6, "var6", def6, fun ?MODULE:test_verification_function/1}],
-    ?assertEqual(lists:sort(ExpectedResult), lists:sort(Result)).
+implicit_variable_redefinition(_) ->
+    mock_ets_tables(),
+    ets:insert(amoc_scenarios, {?MODULE, parametrised}),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    ?assertEqual({error, parameter_overriding, {var0, ?MODULE, ?MODULE}}, Ret).
 
-process_scenario_config_uses_default_values(_) ->
-    ScenarioAttributes = correct_scenario_attributes(),
-    given_scenario_parameters_not_set(ScenarioAttributes),
-    Result = process_scenario_attributes(ScenarioAttributes,[]),
-    assert_settings(Result, ScenarioAttributes).
-
-process_scenario_config_shadows_default_values(_) ->
-    ScenarioAttributes = correct_scenario_attributes(),
-    given_scenario_parameters_set(ScenarioAttributes),
-    AnotherScenarioAttributes = another_correct_scenario_attributes(),
-    AdditionalAttribute = {additional_param, "", value, none},
-    set_env(additional_param, another_value),
-    Result = process_scenario_attributes(
-        [AdditionalAttribute | AnotherScenarioAttributes],
-        [{additional_param, yet_another_value}]),
-    assert_settings(Result, [{additional_param, "", yet_another_value, none} | ScenarioAttributes]).
-
-process_scenario_config_returns_error_for_invalid_values(_) ->
-    IncorrectScenarioAttributes = incorrect_scenario_attributes(),
-    Defaults = correct_scenario_attributes(),
-    given_scenario_parameters_set([{a_name, 3, none} | IncorrectScenarioAttributes]),
-    Result = process_scenario_attributes(
-        [{a_name, <<"binary">>, positive_integer}, {another_name, an_atom, binary} | Defaults],
-        [{unsued_name, whatever_value}, {nonneg_int, -5}]),
+invalid_value(_) ->
+    mock_ets_tables(),
+    ScenarioSettings = [{var2, invalid_value}],
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
     ?assertEqual({error, parameters_verification_failed,
-                  [{pos_int, 0, verification_failed},
-                   {nonneg_int, -5, verification_failed},
-                   {atom, wrong_atom,
-                    {verification_failed,
-                     {not_one_of, [some_atom, another_atom]}}},
-                   {some_binary, an_atom, verification_failed},
-                   {another_binary, "string", verification_failed}]},
-                 Result).
+                  [{var2, invalid_value,
+                    {verification_failed, {not_one_of, [def2, val2]}}}]},
+                 Ret).
 
-process_scenario_config_returns_preprocessed_value(_) ->
-    ValidationFn = fun(_) -> {true, another_atom} end,
-    ScenarioParams = [{preprocessed_param, an_atom, ValidationFn}],
-    {ok, Settings} = amoc_config_scenario:process_scenario_config(ScenarioParams,[]),
-    ?assertEqual([{preprocessed_param, another_atom}],
-                 proplists:lookup_all(preprocessed_param, Settings)).
+invalid_verification_module(_) ->
+    mock_ets_tables(),
+    set_app_env(?APP, config_verification_modules, [invalid_module_name]),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    unset_app_env(?APP, config_verification_modules),
+    ?assertEqual({error, invalid_verification_module,
+                  [{invalid_module_name, nofile}]},
+                 Ret).
 
-assert_settings(Result, ScenarioAttributes) ->
-    ?assertMatch({ok, SettingsList} when is_list(SettingsList), Result),
-    {ok, Settings} = Result,
-    ?assertEqual(length(Settings), length(ScenarioAttributes)),
-    [?assertEqual([{Name, Value}], proplists:lookup_all(Name, Settings)) ||
-        {Name, _, Value, _} <- ScenarioAttributes].
+invalid_parametrised_module(_) ->
+    mock_ets_tables(),
+    ets:insert(amoc_scenarios, {invalid_module_name, parametrised}),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    ?assertEqual({error, invalid_module, invalid_module_name}, Ret).
 
-correct_scenario_attributes() ->
-    scenario_attributes(10000, 0, some_atom, <<"some_binary">>, <<"another_binary">>).
+invalid_module_attributes(_) ->
+    mock_ets_tables(),
+    meck:new(amoc_config_attributes, [non_strict, no_link]),
+    ErrorValue = {error, some_error_type, some_error_reason},
+    meck:expect(amoc_config_attributes, get_module_configuration,
+                fun(_, _, _) -> ErrorValue end),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    ?assertEqual(ErrorValue, Ret),
+    meck:unload().
 
-another_correct_scenario_attributes() ->
-    scenario_attributes(20000, 3, another_atom, <<"yet_another_binary">>, <<"binary">>).
-
-incorrect_scenario_attributes() ->
-    scenario_attributes(0, -1, wrong_atom, an_atom, "string").
-
-scenario_attributes(PosInt, NonNegInt, Atom, BitString1, BitString2) ->
-    [
-        {pos_int, "description", PosInt, positive_integer},
-        {nonneg_int, "description", NonNegInt, nonnegative_integer},
-        {atom, "description", Atom, [some_atom, another_atom]},
-        {some_binary, "description", BitString1, binary},
-        {another_binary, "description", BitString2, fun erlang:is_binary/1}
-    ].
-
-process_scenario_attributes(Attributes, Settings) ->
-    Modules = [?MODULE, verification_module],
-    {ok, Config} = amoc_config_scenario:process_scenario_attributes(Modules, Attributes),
-    amoc_config_scenario:process_scenario_config(Config, Settings).
-
-given_scenario_parameters_not_set(ScenarioAttributes) ->
-    [unset_env(Name) || {Name, _, _, _} <- ScenarioAttributes].
-
-given_scenario_parameters_set(ScenarioAttributes) ->
-    [set_env(Name, Value) || {Name, _, Value, _} <- ScenarioAttributes].
-
-unset_env(Name) ->
-    EnvName = env_name(Name),
-    os:unsetenv(EnvName),
-    false = os:getenv(EnvName).
-
-set_env(Name, Value) ->
-    os:putenv(env_name(Name), format_value(Value)).
-
-env_name(Name) ->
-    "AMOC_" ++ string:uppercase(erlang:atom_to_list(Name)).
-
-format_value(Value) ->
-    io_lib:format("~tp", [Value]).
+mock_ets_tables() ->
+    EtsOptions = [named_table, protected, {read_concurrency, true}],
+    amoc_config = ets:new(amoc_config, EtsOptions),
+    amoc_scenarios = ets:new(amoc_scenarios, EtsOptions).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -6,7 +6,9 @@
 
 -import(amoc_config_helper, [set_app_env/3,
                              unset_app_env/2]).
+
 -define(APP, common_test).
+-define(MOCK_MOD, mock_mod).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% these attributes are required for the testing purposes %%
@@ -14,7 +16,10 @@
 -required_variable({var0, "var0"}).
 -required_variable({var1, "var1"}).
 -required_variable({var2, "var2", def2}).
--override_variable({var2, "var2", val2, [def2, val2]}).
+-override_variable({var2, "var2", val2, [def2, val2], update}).
+-override_variable({var3, "var3", def3, none, update}).
+
+update(Name, Value) -> apply(?MOCK_MOD, update, [Name, Value]).
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -24,21 +29,34 @@ all() ->
      invalid_verification_module,
      invalid_parametrised_module,
      invalid_module_attributes,
-     invalid_value].
+     invalid_settings,
+     invalid_value,
+     {group, update_settings}].
+
+groups() ->
+    [{update_settings, [], [update_settings,
+                            update_settings_readonly,
+                            update_settings_invalid_value,
+                            update_settings_undef_param]}].
+
+init_per_group(update_settings,Config) ->
+    meck:new(?MOCK_MOD, [non_strict, no_link]),
+    meck:expect(?MOCK_MOD, update, ['_', '_'], ok),
+    Config.
+
+end_per_group(update_settings,Config) ->
+    meck:unload(),
+    Config.
 
 parse_scenario_settings(_) ->
     mock_ets_tables(),
     ets:insert(amoc_scenarios, {amoc_controller, parametrised}),
-    ScenarioSettings = [{undefined_var, some_value},
-                        {interarrival, 500},
+    ScenarioSettings = [{interarrival, 500},
                         {var1, def1}],
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
     ?assertEqual(ok, Ret),
-    %% undefined variable provided in settings
-    ?assertThrow({invalid_setting, undefined_var}, amoc_config:get(undefined_var)),
     %% undefined variable
-    ?assertThrow({invalid_setting, another_undefined_var},
-                 amoc_config:get(another_undefined_var)),
+    ?assertThrow({invalid_setting, undefined_var}, amoc_config:get(undefined_var)),
     %% undefined value
     ?assertEqual(undefined, amoc_config:get(var0)),
     ?assertEqual(some_value, amoc_config:get(var0, some_value)),
@@ -50,11 +68,80 @@ parse_scenario_settings(_) ->
     %% parametrised module variable (defined in amoc_controller)
     ?assertEqual(500, amoc_config:get(interarrival)).
 
+update_settings(_) ->
+    mock_ets_tables(),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    ?assertEqual(ok, Ret),
+    ScenarioSettings = [{var3, val3},
+                        {var2, def2}],
+    Ret2 = amoc_config_scenario:update_settings(ScenarioSettings),
+    ?assertEqual(ok, Ret2),
+    %% updated variables
+    ?assertEqual(def2, amoc_config:get(var2)),
+    ?assertEqual(val3, amoc_config:get(var3)),
+    %% unchanged variables
+    ?assertEqual(undefined, amoc_config:get(var0)),
+    ?assertEqual(undefined, amoc_config:get(var1)),
+    [meck:wait(?MOCK_MOD, update, [Name, Value], 500)
+     || {Name, Value} <- ScenarioSettings],
+    meck:reset(?MOCK_MOD).
+
+update_settings_readonly(_) ->
+    mock_ets_tables(),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    Table = ets:tab2list(amoc_config),
+    %% updating readonly parameters
+    ScenarioSettings = [{var0, val0},
+                        {var1, def1},
+                        {var3, val3}],
+    ReadOnlyRet = amoc_config_scenario:update_settings(ScenarioSettings),
+    ?assertEqual({error, readonly_parameters,
+                  [{var0, ?MODULE},
+                   {var1, ?MODULE}]},
+                 ReadOnlyRet),
+    isEqualList(Table, ets:tab2list(amoc_config)),
+    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+
+update_settings_invalid_value(_) ->
+    mock_ets_tables(),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    Table = ets:tab2list(amoc_config),
+    %% invalid value
+    ScenarioSettings2 = [{var3, val3},
+                         {var2, invalid_val2}],
+    InvalidValueRet = amoc_config_scenario:update_settings(ScenarioSettings2),
+    ?assertEqual({error, parameters_verification_failed,
+                  [{var2, invalid_val2,
+                    {verification_failed, {not_one_of, [def2, val2]}}}]},
+                 InvalidValueRet),
+    isEqualList(Table, ets:tab2list(amoc_config)),
+    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+
+update_settings_undef_param(_) ->
+    mock_ets_tables(),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    Table = ets:tab2list(amoc_config),
+    %% undefined parameter
+    ScenarioSettings3 = [{var3, val3},
+                         {invalid_var2, val2}],
+    UndefParamRet = amoc_config_scenario:update_settings(ScenarioSettings3),
+    ?assertEqual({error, undefined_parameters, [invalid_var2]}, UndefParamRet),
+    isEqualList(Table, ets:tab2list(amoc_config)),
+    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+
 implicit_variable_redefinition(_) ->
     mock_ets_tables(),
     ets:insert(amoc_scenarios, {?MODULE, parametrised}),
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
     ?assertEqual({error, parameter_overriding, {var0, ?MODULE, ?MODULE}}, Ret).
+
+invalid_settings(_) ->
+    mock_ets_tables(),
+    ScenarioSettings = [{invalid_var1, invalid_value},
+                        {var2, def2},
+                        {invalid_var2, invalid_value}],
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
+    ?assertEqual({error, undefined_parameters, [invalid_var2, invalid_var1]}, Ret).
 
 invalid_value(_) ->
     mock_ets_tables(),
@@ -94,3 +181,6 @@ mock_ets_tables() ->
     EtsOptions = [named_table, protected, {read_concurrency, true}],
     amoc_config = ets:new(amoc_config, EtsOptions),
     amoc_scenarios = ets:new(amoc_scenarios, EtsOptions).
+
+isEqualList(List1, List2) ->
+    ?assertEqual(lists:sort(List1), lists:sort(List2)).

--- a/test/amoc_config_validation_SUITE.erl
+++ b/test/amoc_config_validation_SUITE.erl
@@ -1,0 +1,104 @@
+-module(amoc_config_validation_SUITE).
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+-import(amoc_config_helper, [set_os_env/2,
+                             unset_os_env/1,
+                             set_app_env/3,
+                             unset_app_env/2]).
+
+-define(MOD, ct).
+-define(APP, common_test).
+
+all() ->
+    [process_scenario_config_uses_default_values,
+     process_scenario_config_shadows_default_values,
+     process_scenario_config_returns_error_for_invalid_values,
+     process_scenario_config_returns_preprocessed_value].
+
+process_scenario_config_uses_default_values(_) ->
+    ScenarioConfig = correct_scenario_config(),
+    given_scenario_os_parameters_not_set(ScenarioConfig),
+    given_scenario_app_parameters_not_set(ScenarioConfig),
+    Result = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    ?assertEqual({ok, ScenarioConfig}, Result).
+
+process_scenario_config_shadows_default_values(_) ->
+    ScenarioConfig = correct_scenario_config(),
+    AnotherScenarioConfig = another_correct_scenario_config(),
+    YetAnotherScenarioConfig = yet_another_correct_scenario_config(),
+    %% set app parameters
+    given_scenario_os_parameters_not_set(ScenarioConfig),
+    given_scenario_app_parameters_set(AnotherScenarioConfig),
+    Result1 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    ?assertEqual({ok, AnotherScenarioConfig}, Result1),
+    %% set also os parameters
+    given_scenario_os_parameters_set(YetAnotherScenarioConfig),
+    Result2 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    ?assertEqual({ok, YetAnotherScenarioConfig}, Result2),
+    %% provide settings
+    Settings = settings_from_scenario_config(ScenarioConfig),
+    Result3 = amoc_config_validation:process_scenario_config(ScenarioConfig, Settings),
+    ?assertEqual({ok, ScenarioConfig}, Result3),
+    %% unset os parameters
+    given_scenario_os_parameters_not_set(ScenarioConfig),
+    Result4 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    ?assertEqual({ok, AnotherScenarioConfig}, Result4),
+    %%unset app parameters
+    given_scenario_app_parameters_not_set(ScenarioConfig).
+
+process_scenario_config_returns_error_for_invalid_values(_) ->
+    VerificationFN = fun(_) -> {false, some_reason} end,
+    IncorrectScenarioConfig =
+        [{wrong_param, ?MOD, any_value, VerificationFN}
+         | incorrect_scenario_config()],
+    given_scenario_os_parameters_not_set(IncorrectScenarioConfig),
+    given_scenario_app_parameters_not_set(IncorrectScenarioConfig),
+    Result = amoc_config_validation:process_scenario_config(IncorrectScenarioConfig, []),
+    ?assertEqual({error, parameters_verification_failed,
+                  [{wrong_param, any_value, {verification_failed, some_reason}},
+                   {some_int, wrong_int, verification_failed},
+                   {some_atom, <<"wrong_atom">>, verification_failed},
+                   {some_binary, "wrong_binary", verification_failed}]},
+                 Result).
+
+process_scenario_config_returns_preprocessed_value(_) ->
+    ValidationFn = fun(_) -> {true, another_atom} end,
+    ScenarioConfig = [{preprocessed_param, ?MOD, an_atom, ValidationFn}],
+    Result = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    ?assertMatch({ok, [{preprocessed_param, ct, another_atom, _}]}, Result).
+
+correct_scenario_config() ->
+    scenario_configuration(1, some_atom, <<"some_binary">>).
+
+another_correct_scenario_config() ->
+    scenario_configuration(2, another_atom, <<"another_binary">>).
+
+yet_another_correct_scenario_config() ->
+    scenario_configuration(3, yet_another_atom, <<"yet_another_binary">>).
+
+incorrect_scenario_config() ->
+    scenario_configuration(wrong_int, <<"wrong_atom">>, "wrong_binary").
+
+scenario_configuration(Int, Atom, Binary) ->
+    [
+        {some_int, ?MOD, Int, fun erlang:is_integer/1},
+        {some_atom, ?MOD, Atom, fun erlang:is_atom/1},
+        {some_binary, ?MOD, Binary, fun erlang:is_binary/1}
+    ].
+
+settings_from_scenario_config(ScenarioConfig) ->
+    [{Name, Value} || {Name, _, Value, _} <- ScenarioConfig].
+
+given_scenario_os_parameters_not_set(ScenarioConfig) ->
+    [unset_os_env(Name) || {Name, _, _, _} <- ScenarioConfig].
+
+given_scenario_os_parameters_set(ScenarioConfig) ->
+    [set_os_env(Name, Value) || {Name, _, Value, _} <- ScenarioConfig].
+
+given_scenario_app_parameters_not_set(ScenarioConfig) ->
+    [unset_app_env(?APP, Name) || {Name, _, _, _} <- ScenarioConfig].
+
+given_scenario_app_parameters_set(ScenarioConfig) ->
+    [set_app_env(?APP, Name, Value) || {Name, _, Value, _} <- ScenarioConfig].

--- a/test/amoc_config_validation_SUITE.erl
+++ b/test/amoc_config_validation_SUITE.erl
@@ -51,7 +51,7 @@ process_scenario_config_shadows_default_values(_) ->
 process_scenario_config_returns_error_for_invalid_values(_) ->
     VerificationFN = fun(_) -> {false, some_reason} end,
     IncorrectScenarioConfig =
-        [{wrong_param, ?MOD, any_value, VerificationFN}
+        [{wrong_param, ?MOD, any_value, VerificationFN, read_only}
          | incorrect_scenario_config()],
     given_scenario_os_parameters_not_set(IncorrectScenarioConfig),
     given_scenario_app_parameters_not_set(IncorrectScenarioConfig),
@@ -65,9 +65,9 @@ process_scenario_config_returns_error_for_invalid_values(_) ->
 
 process_scenario_config_returns_preprocessed_value(_) ->
     ValidationFn = fun(_) -> {true, another_atom} end,
-    ScenarioConfig = [{preprocessed_param, ?MOD, an_atom, ValidationFn}],
+    ScenarioConfig = [{preprocessed_param, ?MOD, an_atom, ValidationFn, read_only}],
     Result = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
-    ?assertMatch({ok, [{preprocessed_param, ct, another_atom, _}]}, Result).
+    ?assertMatch({ok, [{preprocessed_param, ct, another_atom, _, read_only}]}, Result).
 
 correct_scenario_config() ->
     scenario_configuration(1, some_atom, <<"some_binary">>).
@@ -83,22 +83,22 @@ incorrect_scenario_config() ->
 
 scenario_configuration(Int, Atom, Binary) ->
     [
-        {some_int, ?MOD, Int, fun erlang:is_integer/1},
-        {some_atom, ?MOD, Atom, fun erlang:is_atom/1},
-        {some_binary, ?MOD, Binary, fun erlang:is_binary/1}
+        {some_int, ?MOD, Int, fun erlang:is_integer/1, read_only},
+        {some_atom, ?MOD, Atom, fun erlang:is_atom/1, read_only},
+        {some_binary, ?MOD, Binary, fun erlang:is_binary/1, read_only}
     ].
 
 settings_from_scenario_config(ScenarioConfig) ->
-    [{Name, Value} || {Name, _, Value, _} <- ScenarioConfig].
+    [{Name, Value} || {Name, _, Value, _, _} <- ScenarioConfig].
 
 given_scenario_os_parameters_not_set(ScenarioConfig) ->
-    [unset_os_env(Name) || {Name, _, _, _} <- ScenarioConfig].
+    [unset_os_env(Name) || {Name, _, _, _, _} <- ScenarioConfig].
 
 given_scenario_os_parameters_set(ScenarioConfig) ->
-    [set_os_env(Name, Value) || {Name, _, Value, _} <- ScenarioConfig].
+    [set_os_env(Name, Value) || {Name, _, Value, _, _} <- ScenarioConfig].
 
 given_scenario_app_parameters_not_set(ScenarioConfig) ->
-    [unset_app_env(?APP, Name) || {Name, _, _, _} <- ScenarioConfig].
+    [unset_app_env(?APP, Name) || {Name, _, _, _, _} <- ScenarioConfig].
 
 given_scenario_app_parameters_set(ScenarioConfig) ->
-    [set_app_env(?APP, Name, Value) || {Name, _, Value, _} <- ScenarioConfig].
+    [set_app_env(?APP, Name, Value) || {Name, _, Value, _, _} <- ScenarioConfig].

--- a/test/amoc_config_verification_SUITE.erl
+++ b/test/amoc_config_verification_SUITE.erl
@@ -1,4 +1,4 @@
--module(amoc_config_validation_SUITE).
+-module(amoc_config_verification_SUITE).
 -include_lib("eunit/include/eunit.hrl").
 -include("../src/amoc_config/amoc_config.hrl").
 
@@ -22,7 +22,7 @@ process_scenario_config_uses_default_values(_) ->
     ScenarioConfig = correct_scenario_config(),
     given_scenario_os_parameters_not_set(ScenarioConfig),
     given_scenario_app_parameters_not_set(ScenarioConfig),
-    Result = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    Result = amoc_config_verification:process_scenario_config(ScenarioConfig, []),
     ?assertEqual({ok, ScenarioConfig}, Result).
 
 process_scenario_config_shadows_default_values(_) ->
@@ -32,19 +32,19 @@ process_scenario_config_shadows_default_values(_) ->
     %% set app parameters
     given_scenario_os_parameters_not_set(ScenarioConfig),
     given_scenario_app_parameters_set(AnotherScenarioConfig),
-    Result1 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    Result1 = amoc_config_verification:process_scenario_config(ScenarioConfig, []),
     ?assertEqual({ok, AnotherScenarioConfig}, Result1),
     %% set also os parameters
     given_scenario_os_parameters_set(YetAnotherScenarioConfig),
-    Result2 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    Result2 = amoc_config_verification:process_scenario_config(ScenarioConfig, []),
     ?assertEqual({ok, YetAnotherScenarioConfig}, Result2),
     %% provide settings
     Settings = settings_from_scenario_config(ScenarioConfig),
-    Result3 = amoc_config_validation:process_scenario_config(ScenarioConfig, Settings),
+    Result3 = amoc_config_verification:process_scenario_config(ScenarioConfig, Settings),
     ?assertEqual({ok, ScenarioConfig}, Result3),
     %% unset os parameters
     given_scenario_os_parameters_not_set(ScenarioConfig),
-    Result4 = amoc_config_validation:process_scenario_config(ScenarioConfig, []),
+    Result4 = amoc_config_verification:process_scenario_config(ScenarioConfig, []),
     ?assertEqual({ok, AnotherScenarioConfig}, Result4),
     %%unset app parameters
     given_scenario_app_parameters_not_set(ScenarioConfig).
@@ -57,7 +57,7 @@ process_scenario_config_returns_error_for_invalid_values(_) ->
      | incorrect_scenario_config()],
     given_scenario_os_parameters_not_set(IncorrectScenarioConfig),
     given_scenario_app_parameters_not_set(IncorrectScenarioConfig),
-    Result = amoc_config_validation:process_scenario_config(IncorrectScenarioConfig, []),
+    Result = amoc_config_verification:process_scenario_config(IncorrectScenarioConfig, []),
     ?assertEqual({error, parameters_verification_failed,
                   [{wrong_param, any_value, {verification_failed, some_reason}},
                    {some_int, wrong_int, verification_failed},
@@ -66,11 +66,11 @@ process_scenario_config_returns_error_for_invalid_values(_) ->
                  Result).
 
 process_scenario_config_returns_preprocessed_value(_) ->
-    ValidationFn = fun(_) -> {true, another_atom} end,
+    VerificationFn = fun(_) -> {true, another_atom} end,
     PreprocessedParam = #module_parameter{name = preprocessed_param,
                                           mod = ?MOD, value = an_atom,
-                                          verification_fn = ValidationFn},
-    Result = amoc_config_validation:process_scenario_config([PreprocessedParam], []),
+                                          verification_fn = VerificationFn},
+    Result = amoc_config_verification:process_scenario_config([PreprocessedParam], []),
     ?assertEqual({ok, [PreprocessedParam#module_parameter{value = another_atom}]}, Result).
 
 correct_scenario_config() ->


### PR DESCRIPTION
This pull request adds the next functionality:
- configuration of the helper modules in the same way as scenarios (using `-required_variable(...)` module attribute).
- explicit overriding of parameters declaration in a scenario. It might be required to change update method for some parameters for some scenarios
- possibility to update settings using `amoc_controller:update_settings()` interface. Only if update method is set explicitly for the parameter, otherwise it's `read_only`
- changed format of the `-required_variable(...)` module attribute declaration. the new format is declared [here](https://github.com/esl/amoc/pull/125/files#diff-e8fe86ae2ae8a2937a93118cc3b43ac5R52). the old format is still supported.
- extended testing of amoc_config_* modules.

overview of the amoc_config_* modules:
- `amoc_config` - getter module, the only one that is supposed to be used by helper/scenario modules.
- `amoc_config_env` - contains functionality for parsing (os) env variables.
- `amoc_config_attributes` - parsing/validation of the `-required_variable(...)` module attributes.
- `amoc_config_validation` - verification of the parameters values.
- `amoc_config_scenario` - composition of the `-required_variable(...)` attributes from all the helpers and started scenario, runtime update of the values. 
- `amoc_config_utils` various helper functions.
- `amoc_scenario` - collects a list of all the parametrized helper modules.

open questions:
- do we want to support an old format of the `-required_variable(...)` module attributes?
- do we want to keep `config_verification_modules`? It's quite complex but I don't know how to deal with it better. currently it works in the next way:
    - if verification/update method is an atom, first we try to find an exported function in the module that declares variable.
    - then we check the modules mentioned in `config_verification_modules` env of the module's application.
    - then we check the modules mentioned in `config_verification_modules` env of all other loaded applications.

