### PR TITLE
Scenario descr rest api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM phusion/baseimage as amoc-build
+FROM phusion/baseimage:18.04-1.0.0 as amoc-build
 
 ARG otp_vsn=22.3.4-1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git \
-        make \
-        wget && \
-    wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    dpkg -i erlang-solutions_1.0_all.deb && \
+                    git make wget gnupg && \
+    wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
+    dpkg -i erlang-solutions_2.0_all.deb && \
     apt-get update && \
     apt-get install -y esl-erlang=1:${otp_vsn}
 
@@ -18,7 +16,7 @@ RUN cd amoc_build && \
     git clean -ffxd && \
     make rel
 
-FROM phusion/baseimage
+FROM phusion/baseimage:18.04-1.0.0
 MAINTAINER Erlang Solutions <mongoose-im@erlang-solutions.com>
 
 RUN useradd -ms /bin/bash amoc

--- a/doc/http-api.md
+++ b/doc/http-api.md
@@ -16,5 +16,5 @@ With default options API will be running on port 4000. You can set other port by
 In Amoc we use Swagger so if you want the current documentation in a nice format you can find it under `/api-docs/` path.
 Just open it in your browser (e.g. http://localhost:4000/api-docs/)
 
-Also you can find the current documentation [here](https://esl.github.io/amoc_rest/?v=1.0.0)
+Also you can find the current documentation [here](https://esl.github.io/amoc_rest/?v=7a46d9f)
 (without possibility to execute requests)

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,8 @@
     {exometer_core, {git, "https://github.com/esl/exometer_core.git", {branch, "master"}}},
     {exometer_report_graphite, {git, "https://github.com/esl/exometer_report_graphite.git", {branch, "master"}}},
     %% when updating amoc_rest version, don't forget to update it at ./doc/http-api.md as well.
-    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {ref, "7a46d9f"}}}
+    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {ref, "7a46d9f"}}},
+    {docsh, "0.7.2"}
 ]}.
 
 { profiles, [
@@ -22,7 +23,7 @@
     {prod, [
         {erl_opts, [{src_dirs, ["src", "scenarios"]}]},
         {relx, [
-            {release, {amoc, git}, [amoc, runtime_tools, compiler]},
+            {release, {amoc, git}, [amoc, runtime_tools, compiler, docsh]},
             {dev_mode, false},
             {include_erts, true},
             {include_src, false},

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
     {exometer_core, {git, "https://github.com/esl/exometer_core.git", {branch, "master"}}},
     {exometer_report_graphite, {git, "https://github.com/esl/exometer_report_graphite.git", {branch, "master"}}},
     %% when updating amoc_rest version, don't forget to update it at ./doc/http-api.md as well.
-    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {tag, "1.0.0"}}}
+    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {ref, "7a46d9f"}}}
 ]}.
 
 { profiles, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,6 +5,7 @@
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.8.0">>},1},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.9.1">>},2},
+ {<<"docsh">>,{pkg,<<"docsh">>,<<"0.7.2">>},0},
  {<<"exometer_core">>,
   {git,"https://github.com/esl/exometer_core.git",
        {ref,"979ff04bcabc276c122b47fb7e6b54fbded62576"}},
@@ -13,10 +14,12 @@
   {git,"https://github.com/esl/exometer_report_graphite.git",
        {ref,"264dd7bcbadbd7febcd43917302251286c88b681"}},
   0},
+ {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},2},
  {<<"hut">>,{pkg,<<"hut">>,<<"1.2.1">>},1},
  {<<"jesse">>,{pkg,<<"jesse">>,<<"1.5.5">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.11.0">>},1},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
+ {<<"providers">>,{pkg,<<"providers">>,<<"1.8.1">>},1},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},2},
  {<<"rfc3339">>,
   {git,"https://github.com/talentdeficit/rfc3339.git",
@@ -26,9 +29,12 @@
 {pkg_hash,[
  {<<"cowboy">>, <<"F3DC62E35797ECD9AC1B50DB74611193C29815401E53BAC9A5C0577BD7BC667D">>},
  {<<"cowlib">>, <<"61A6C7C50CF07FDD24B2F45B89500BB93B6686579B069A89F88CB211E1125C78">>},
+ {<<"docsh">>, <<"F893D5317A0E14269DD7FE79CF95FB6B9BA23513DA0480EC6E77C73221CAE4F2">>},
+ {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
  {<<"hut">>, <<"08D46679523043424870723923971889E8A34D63B2F946A35B46CF921D1236E7">>},
  {<<"jesse">>, <<"ECFD2C1634C49052CA907B4DFDE1D1F44B7FD7862D933F4590807E42759B8072">>},
  {<<"jsx">>, <<"08154624050333919B4AC1B789667D5F4DB166DC50E190C4D778D1587F102EE0">>},
  {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"providers">>, <<"70B4197869514344A8A60E2B2A4EF41CA03DEF43CFB1712ECF076A0F3C62F083">>},
  {<<"ranch">>, <<"6B1FAB51B49196860B733A49C07604465A47BDB78AA10C1C16A3D199F7F8C881">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"amoc_rest">>,
   {git,"https://github.com/esl/amoc_rest.git",
-       {ref,"59ccffad8fa3662bde44f54772a01c60192f8b04"}},
+       {ref,"7a46d9f083692427fcbd2e4a83a01f6ca2d735da"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.8.0">>},1},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.9.1">>},2},

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -37,6 +37,7 @@
 -record(module_parameter, {name :: name(),
                            mod :: module(),
                            value :: value(),
+                           description :: string(),
                            verification_fn :: maybe_verification_fun(),
                            update_fn = read_only :: maybe_update_fun() | read_only}).
 

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -111,15 +111,16 @@ check_update_method(Attr) ->
     end.
 
 -spec make_module_parameter(#{name := name(),
+                              description := string(),
                               default_value := value(),
                               verification := maybe_verification_fun(),
                               update := maybe_update_fun(),
                               any() => any()},
                             module()) ->
     {ok, module_parameter()}.
-make_module_parameter(#{name := Name, default_value := Value, update := UpdateFn,
-                        verification := VerificationFn}, Module) ->
-    {ok, #module_parameter{name = Name, mod = Module, value = Value,
+make_module_parameter(#{name := Name, description := Description, default_value := Value,
+                        verification := VerificationFn, update := UpdateFn}, Module) ->
+    {ok, #module_parameter{name = Name, mod = Module, description = Description, value = Value,
                            verification_fn = VerificationFn, update_fn = UpdateFn}}.
 
 -spec verification_fn(maybe_verification_method()) ->

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -13,7 +13,8 @@
 -include_lib("kernel/include/logger.hrl").
 -include("amoc_config.hrl").
 
--type module_configuration_map() :: #{name() => #{any() => any()}}.
+-type module_configuration_map() :: #{name() => #{value := any(),
+                                                  any() => any()}}.
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
@@ -142,7 +143,7 @@ store_scenario_config(Config) ->
 convert_to_config_map(Config) ->
     PropList = [{Name, parameter_to_map(P)}
                 || #module_parameter{name = Name} = P <- Config],
-    maps:from_list(PropList).
+    {ok, maps:from_list(PropList)}.
 
 parameter_to_map(#module_parameter{} = Param) ->
     RecordFields = record_info(fields, module_parameter),

--- a/src/amoc_config/amoc_config_scenario.erl
+++ b/src/amoc_config/amoc_config_scenario.erl
@@ -6,11 +6,14 @@
 
 %% API
 -export([parse_scenario_settings/2,
-         update_settings/1]).
+         update_settings/1,
+         get_default_configuration/1,
+         get_current_configuration/0]).
 
 -include_lib("kernel/include/logger.hrl").
 -include("amoc_config.hrl").
 
+-type module_configuration_map() :: #{name() => #{any() => any()}}.
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
@@ -42,6 +45,20 @@ update_settings(Settings) ->
         UnexpectedReturnValue ->
             {error, invalid_return_value, UnexpectedReturnValue}
     end.
+
+-spec get_default_configuration(module()) -> {ok, module_configuration_map()} | error().
+get_default_configuration(Module) ->
+    PipelineActions = [
+        {fun get_configuration/1, []},
+        {fun convert_to_config_map/1, []}],
+    amoc_config_utils:pipeline(PipelineActions, {ok, Module}).
+
+-spec get_current_configuration() -> {ok, module_configuration_map()}.
+get_current_configuration() ->
+    PipelineActions = [
+        {fun get_existing_configuration/0, []},
+        {fun convert_to_config_map/1, []}],
+    amoc_config_utils:pipeline(PipelineActions, ok).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
@@ -121,3 +138,19 @@ store_scenario_config(Config) ->
     [spawn(fun() -> apply(Fn, [Name, Value]) end)
      || #module_parameter{name = Name, value = Value, update_fn = Fn} <- Config],
     ok.
+
+convert_to_config_map(Config) ->
+    PropList = [{Name, parameter_to_map(P)}
+                || #module_parameter{name = Name} = P <- Config],
+    maps:from_list(PropList).
+
+parameter_to_map(#module_parameter{} = Param) ->
+    RecordFields = record_info(fields, module_parameter),
+    RecordSize = record_info(size, module_parameter),
+    FieldsWithPosition = lists:zip(lists:seq(2, RecordSize), RecordFields),
+    PropList = [{Field, element(Pos, Param)} || {Pos, Field} <- FieldsWithPosition,
+                                                filter_parameter_fields(Field)],
+    maps:from_list(PropList).
+
+filter_parameter_fields(name) -> false;
+filter_parameter_fields(_)    -> true.

--- a/src/rest_api/amoc_api_logic_handler.erl
+++ b/src/rest_api/amoc_api_logic_handler.erl
@@ -44,6 +44,16 @@ handle_request('ScenariosIdGet', _Req, #{id := ScenarioName}) ->
                 amoc_api_scenario_status:maybe_scenario_settings(Status, Scenario),
             {200, #{}, [{<<"scenario_status">>, BinStatus} | MaybeSettings]}
     end;
+handle_request('ScenariosIdInfoGet', _Req, #{id := ScenarioName}) ->
+    case amoc_api_scenario_status:test_status(ScenarioName) of
+        {doesnt_exist, _} ->
+            {404, #{}, #{}};
+        {_Status, Scenario} ->
+            EDoc = amoc_api_scenario_status:get_edoc(Scenario),
+            MaybeParams =
+                amoc_api_scenario_status:maybe_scenario_params(Scenario),
+            {200, #{}, [{<<"doc">>, EDoc} | MaybeParams]}
+    end;
 handle_request('ScenariosIdPatch', _Req, #{'ScenarioExecution' := Body,
                                            id := ScenarioName}) ->
     Error = {200, #{}, [{<<"scenario">>, <<"error">>}]},

--- a/src/rest_api/amoc_api_logic_handler.erl
+++ b/src/rest_api/amoc_api_logic_handler.erl
@@ -38,9 +38,11 @@ handle_request('ScenariosIdGet', _Req, #{id := ScenarioName}) ->
     case amoc_api_scenario_status:test_status(ScenarioName) of
         {doesnt_exist, _} ->
             {404, #{}, #{}};
-        {Status, _Scenario} ->
+        {Status, Scenario} ->
             BinStatus = atom_to_binary(Status, utf8),
-            {200, #{}, [{<<"scenario_status">>, BinStatus}]}
+            MaybeSettings =
+                amoc_api_scenario_status:maybe_scenario_settings(Status, Scenario),
+            {200, #{}, [{<<"scenario_status">>, BinStatus} | MaybeSettings]}
     end;
 handle_request('ScenariosIdPatch', _Req, #{'ScenarioExecution' := Body,
                                            id := ScenarioName}) ->

--- a/src/rest_api/amoc_api_scenario_status.erl
+++ b/src/rest_api/amoc_api_scenario_status.erl
@@ -69,15 +69,15 @@ format(Value) ->
 
 -spec scenario_settings(status(), amoc:scenario()) -> amoc_config:settings().
 scenario_settings(loaded, Scenario) ->
-    ConfigMap = amoc_config_scenario:get_default_configuration(Scenario),
+    {ok, ConfigMap} = amoc_config_scenario:get_default_configuration(Scenario),
     [{Name, Value} || {Name, #{value := Value}} <- maps:to_list(ConfigMap)];
 scenario_settings(running, _Scenario) ->
-    ConfigMap = amoc_config_scenario:get_current_configuration(),
+    {ok, ConfigMap} = amoc_config_scenario:get_current_configuration(),
     [{Name, Value} || {Name, #{value := Value}} <- maps:to_list(ConfigMap)];
 scenario_settings(_, _Scenario) -> [].
 
 scenario_parameters(Scenario) ->
-    ConfigMap = amoc_config_scenario:get_default_configuration(Scenario),
+    {ok, ConfigMap} = amoc_config_scenario:get_default_configuration(Scenario),
     [{Name, maps:to_list(Info)} || {Name, Info} <- maps:to_list(ConfigMap)].
 
     -spec get_scenario(binary()) -> {ok, amoc:scenario()} | doesnt_exist.

--- a/src/rest_api/amoc_api_scenario_status.erl
+++ b/src/rest_api/amoc_api_scenario_status.erl
@@ -42,7 +42,7 @@ test_status(ScenarioName) ->
 
 maybe_scenario_settings(Status, Scenario)->
     case scenario_settings(Status, Scenario) of
-        []->[];
+        [] -> [];
         Settings ->
             FormattedSettings = [{format(K), format(V)} || {K, V} <- Settings],
             [{<<"settings">>, FormattedSettings}]
@@ -50,7 +50,7 @@ maybe_scenario_settings(Status, Scenario)->
 
 maybe_scenario_params(Scenario)->
     case scenario_parameters(Scenario) of
-        []->[];
+        [] -> [];
         Parameters ->
             FormattedParameters = [{format(K), format_kv_list(V)}
                                    || {K, V} <- Parameters],
@@ -80,7 +80,7 @@ scenario_parameters(Scenario) ->
     {ok, ConfigMap} = amoc_config_scenario:get_default_configuration(Scenario),
     [{Name, maps:to_list(Info)} || {Name, Info} <- maps:to_list(ConfigMap)].
 
-    -spec get_scenario(binary()) -> {ok, amoc:scenario()} | doesnt_exist.
+-spec get_scenario(binary()) -> {ok, amoc:scenario()} | doesnt_exist.
 get_scenario(ScenarioName) ->
     try
         {ok, binary_to_existing_atom(ScenarioName, utf8)}

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -37,9 +37,9 @@ all() ->
      patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings
     ].
 
-init_per_testcase(Mod, Config)
-    when Mod =:= patch_scenario_returns_200_when_request_ok_and_module_exists;
-         Mod =:= patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings ->
+init_per_testcase(TC, Config)
+    when TC =:= patch_scenario_returns_200_when_request_ok_and_module_exists;
+         TC =:= patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings ->
     mock_amoc_dist_do(),
     create_env(Config),
     Config;
@@ -48,7 +48,9 @@ init_per_testcase(_, Config) ->
     create_env(Config),
     Config.
 
-end_per_testcase(patch_scenario_returns_200_when_request_ok_and_module_exists, _Config) ->
+end_per_testcase(TC, _Config)
+    when TC =:= patch_scenario_returns_200_when_request_ok_and_module_exists;
+         TC =:= patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings ->
     ok = meck:unload(amoc_dist),
     destroy_env();
 end_per_testcase(_, _Config) ->
@@ -178,7 +180,9 @@ destroy_env() ->
 -spec given_test_status_mocked(atom()) -> ok.
 given_test_status_mocked(Value) ->
     meck:new(amoc_api_scenario_status, []),
-    meck:expect(amoc_api_scenario_status, test_status, fun(_) -> Value end).
+    meck:expect(amoc_api_scenario_status, test_status, fun(_) -> Value end),
+    meck:expect(amoc_api_scenario_status, maybe_scenario_settings,
+                fun(_, _) -> [] end).
 
 -spec mock_amoc_dist_do() -> ok.
 mock_amoc_dist_do() ->

--- a/test/amoc_api_scenarios_handler_SUITE.erl
+++ b/test/amoc_api_scenarios_handler_SUITE.erl
@@ -7,6 +7,9 @@
 -define(SCENARIOS_URL_S, "/scenarios").
 -define(SCENARIOS_URL_U, "/scenarios/upload").
 
+-define(SCENARIOS_URL_I(Module), ?SCENARIOS_URL_S ++ "/" ++
+                                 atom_to_list(Module) ++ "/info").
+
 -define(SAMPLE_SCENARIO, sample_test).
 -define(SAMPLE_SCENARIO_DECLARATION,
         "-module(" ++ atom_to_list(?SAMPLE_SCENARIO) ++ ").").
@@ -17,7 +20,9 @@
          get_scenarios_returns_200_and_scenarios_list_when_requested/1,
          put_scenarios_returns_400_and_error_when_scenario_is_not_valid/1,
          put_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid/1,
-         put_scenarios_returns_200_when_scenario_valid/1
+         put_scenarios_returns_200_when_scenario_valid/1,
+         get_scenario_info_returns_404_when_scenario_does_not_exist/1,
+         get_scenario_info_returns_200_when_scenario_exists/1
         ]).
 
 
@@ -26,7 +31,9 @@ all() ->
      get_scenarios_returns_200_and_scenarios_list_when_requested,
      put_scenarios_returns_400_and_error_when_scenario_is_not_valid,
      put_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid,
-     put_scenarios_returns_200_when_scenario_valid
+     put_scenarios_returns_200_when_scenario_valid,
+     get_scenario_info_returns_404_when_scenario_does_not_exist,
+     get_scenario_info_returns_200_when_scenario_exists
     ].
 
 
@@ -34,7 +41,9 @@ init_per_testcase(_, Config) ->
     amoc_api_helper:start_amoc(),
     Config.
 
-end_per_testcase(put_scenarios_returns_200_when_scenario_valid, _Config) ->
+end_per_testcase(TestCase, _Config)
+    when TestCase =:= get_scenario_info_returns_200_when_scenario_exists;
+         TestCase =:= put_scenarios_returns_200_when_scenario_valid ->
     amoc_api_helper:remove_module(?SAMPLE_SCENARIO),
     amoc_api_helper:stop_amoc();
 end_per_testcase(_, _Config) ->
@@ -47,7 +56,8 @@ get_scenarios_returns_200_and_scenarios_list_when_requested(_Config) ->
     {[{Key, Scenarios}]} = Body,
     ?assertEqual(200, CodeHttp),
     ?assertEqual(<<"scenarios">>, Key),
-    ?assert(is_list(Scenarios)).
+    ?assert(is_list(Scenarios)),
+    Scenarios.
 
 put_scenarios_returns_400_and_error_when_scenario_is_not_valid(_Config) ->
     %% given
@@ -73,7 +83,7 @@ put_scenarios_returns_200_and_compile_error_when_scenario_source_not_valid(_Conf
               "\n                      [{2,erl_parse,[\"syntax error before: \",[]]}]}]\n">>,
     ?assertEqual({[{<<"compile">>, Error}]}, Body).
 
-put_scenarios_returns_200_when_scenario_valid(_Config) ->
+put_scenarios_returns_200_when_scenario_valid(Config) ->
     %% given
     ScenarioContent = ?DUMMY_SCENARIO_MODULE(?SAMPLE_SCENARIO),
     %% when
@@ -84,4 +94,57 @@ put_scenarios_returns_200_when_scenario_valid(_Config) ->
     ?assertEqual(200, CodeHttp),
     ?assertEqual({[{<<"compile">>, <<"ok">>}]}, Body),
     ?assert(filelib:is_regular(ScenarioFileSource)),
-    ?assert(filelib:is_regular(ScenarioFileBeam)).
+    ?assert(filelib:is_regular(ScenarioFileBeam)),
+    Scenarios = get_scenarios_returns_200_and_scenarios_list_when_requested(Config),
+    ?assertEqual(true, lists:member(atom_to_binary(?SAMPLE_SCENARIO, utf8), Scenarios)).
+
+
+get_scenario_info_returns_404_when_scenario_does_not_exist(_Config) ->
+    %% when
+    {CodeHttp, _Body} = amoc_api_helper:get(?SCENARIOS_URL_I(?SAMPLE_SCENARIO)),
+    %% then
+    ?assertEqual(404, CodeHttp).
+
+get_scenario_info_returns_200_when_scenario_exists(Config) ->
+    %% given scenario exists
+    put_scenarios_returns_200_when_scenario_valid(Config),
+    mock_amoc_amoc_scenario(),
+    %% when
+    {CodeHttp, Body} = amoc_api_helper:get(?SCENARIOS_URL_I(?SAMPLE_SCENARIO)),
+    ?assertEqual(200, CodeHttp),
+    BodyMap = json_to_map(Body),
+    ExpectedInfo = #{<<"doc">> => <<"\nsome edoc\n\n">>,
+                     <<"parameters">> =>
+                         #{<<"interarrival">> =>
+                               #{<<"default_value">> => <<"50">>,
+                                 <<"description">> => <<"\"a delay between creating the"
+                                                        " processes for two consecutive"
+                                                        " users (ms, def: 50ms)\"">>,
+                                 <<"module">> => <<"amoc_controller">>,
+                                 <<"update_fn">> =>
+                                 <<"fun amoc_controller:maybe_update_interarrival_timer/2">>,
+                                 <<"verification_fn">> =>
+                                 <<"fun amoc_controller:positive_integer/1">>},
+                           <<"some_parameter">> =>
+                               #{<<"default_value">> => <<"undefined">>,
+                                 <<"description">> => <<"\"some parameter\"">>,
+                                 <<"module">> => <<"sample_test">>,
+                                 <<"update_fn">> => <<"read_only">>,
+                                 <<"verification_fn">> =>
+                                 <<"fun amoc_config_attributes:none/1">>}}},
+    ?assertEqual(ExpectedInfo, BodyMap),
+    meck:unload(amoc_scenario).
+
+mock_amoc_amoc_scenario() ->
+    ok = meck:new(amoc_scenario, [passthrough]),
+    Fun = fun() ->
+            Modules = meck:passthrough([]),
+            Modules -- [amoc_config_scenario_SUITE, amoc_config_attributes_SUITE]
+          end,
+    ok = meck:expect(amoc_scenario, list_configurable_modules, Fun).
+
+json_to_map({List}) when is_list(List) ->
+    maps:from_list([{K, json_to_map(V)} || {K, V} <- List]);
+json_to_map(List) when is_list(List) ->
+    [json_to_map(Element) || Element <- List];
+json_to_map(AnythingElse) -> AnythingElse.

--- a/test/scenario_template.hrl
+++ b/test/scenario_template.hrl
@@ -1,6 +1,13 @@
 -define(DUMMY_SCENARIO_MODULE(Name), <<"
+%%==============================================================================
+%% @doc
+%%   some edoc
+%% @end
+%%==============================================================================
 -module(",(atom_to_binary(Name,utf8))/binary,").
 -behaviour(amoc_scenario).
+
+-required_variable(#{name => some_parameter, description => \"some parameter\"}).
 
 -export([start/1]).
 -export([init/0]).


### PR DESCRIPTION
Implementation of `/scenarios/{id}/info` and update of  `/scenarios/{id}` GET methods.
`/scenarios/{id}` is tested manually. I haven't extended tests for it since we are going to rework it in the next iteration. 