### PR TITLE
REST API for scenario execution

### DIFF
--- a/doc/http-api.md
+++ b/doc/http-api.md
@@ -16,5 +16,5 @@ With default options API will be running on port 4000. You can set other port by
 In Amoc we use Swagger so if you want the current documentation in a nice format you can find it under `/api-docs/` path.
 Just open it in your browser (e.g. http://localhost:4000/api-docs/)
 
-Also you can find the current documentation [here](https://esl.github.io/amoc_rest/?v=7a46d9f)
+Also you can find the current documentation [here](https://esl.github.io/amoc_rest/?v=1d615924)
 (without possibility to execute requests)

--- a/integration_test/test_run_scenario.sh
+++ b/integration_test/test_run_scenario.sh
@@ -8,14 +8,14 @@ enable_strict_mode
 #############################
 run_scenario() {
     local port="$(amoc_container_port "$1")"
-    local json_body='{ "users": '"$3"' , "settings" : { "test" : "<<\"test_value\">>" } }'
+    local json_body='{ "scenario": "'"$2"'", "users": '"$3"' , "settings" : { "test" : "<<\"test_value\">>" } }'
     curl -X PATCH --header 'Content-Type: application/json' --header 'Accept: application/json' \
-         -s -d "$json_body" "http://localhost:${port}/scenarios/$2"
+         -s  -w "%{http_code}" -o /dev/null -d "$json_body" "http://localhost:${port}/execution/start"
 }
 
 result="$(run_scenario amoc-1 dummy_scenario 10)"
 
-if echo ${result} | contain started; then
+if [ "$result" = "200" ]; then
     echo "Scenario executed"
     exit 0
 else

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
     {exometer_core, {git, "https://github.com/esl/exometer_core.git", {branch, "master"}}},
     {exometer_report_graphite, {git, "https://github.com/esl/exometer_report_graphite.git", {branch, "master"}}},
     %% when updating amoc_rest version, don't forget to update it at ./doc/http-api.md as well.
-    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {ref, "7a46d9f"}}},
+    {amoc_rest, {git, "https://github.com/esl/amoc_rest.git", {ref, "1d615924"}}},
     {docsh, "0.7.2"}
 ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"amoc_rest">>,
   {git,"https://github.com/esl/amoc_rest.git",
-       {ref,"7a46d9f083692427fcbd2e4a83a01f6ca2d735da"}},
+       {ref,"1d6159242ff2247fc98332bf91cc208f832dc1d7"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.8.0">>},1},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.9.1">>},2},

--- a/src/rest_api/amoc_api_scenario_status.erl
+++ b/src/rest_api/amoc_api_scenario_status.erl
@@ -10,7 +10,7 @@
          get_edoc/1]).
 
 -type status() :: error | running | finished | loaded | doesnt_exist.
--type scenario_status() :: {status(), amoc:scenario()}.
+-type scenario_status() :: {status(), amoc:scenario() | invalid_scenario_name}.
 
 get_edoc(Scenario) ->
     case docsh_lib:get_docs(Scenario) of

--- a/test/amoc_api_execution_handler_SUITE.erl
+++ b/test/amoc_api_execution_handler_SUITE.erl
@@ -1,0 +1,181 @@
+-module(amoc_api_execution_handler_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("scenario_template.hrl").
+
+-compile(export_all).
+
+all() ->
+    [start_scenario,
+     start_scenario_with_users_and_settings,
+     fail_to_start_non_existing_scenario,
+     fail_to_start_scenario_without_name,
+     stop_scenario,
+     fail_to_stop_scenario_when_not_running,
+     add_users,
+     add_users_on_nodes,
+     fail_to_add_users_when_not_running,
+     remove_users,
+     remove_users_on_nodes,
+     fail_to_remove_users_when_not_running,
+     update_settings,
+     update_settings_on_nodes,
+     fail_to_update_settings_when_not_running].
+
+%% Setup and teardown
+
+init_per_suite(Config) ->
+    amoc_api_helper:start_amoc(),
+    ok = amoc_scenario:install_module(sample_test, dummy_scenario_module()),
+    Config.
+
+end_per_suite(_Config) ->
+    amoc_api_helper:remove_module(sample_test),
+    amoc_api_helper:stop_amoc().
+
+init_per_testcase(TC, Config) ->
+    meck:new(amoc_dist, [passthrough]),
+    setup_meck(TC),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    meck:unload(amoc_dist).
+
+setup_meck(start_scenario) ->
+    meck:expect(amoc_dist, do, fun(sample_test, 0, []) -> {ok, mocked} end);
+setup_meck(start_scenario_with_users_and_settings) ->
+    meck:expect(amoc_dist, do, fun(sample_test, 10, Settings) ->
+                                       ?assertEqual(lists:sort(Settings), lists:sort(settings())),
+                                       {ok, mocked}
+                               end);
+setup_meck(stop_scenario) ->
+    meck:expect(amoc_dist, stop, fun() -> {ok, mocked} end);
+setup_meck(add_users) ->
+    meck:expect(amoc_dist, add, fun(10) -> {ok, mocked} end);
+setup_meck(add_users_on_nodes) ->
+    meck:expect(amoc_dist, add, fun(10, [node1@host1, node2@host2]) -> {ok, mocked} end);
+setup_meck(remove_users) ->
+    meck:expect(amoc_dist, remove, fun(10, false) -> {ok, mocked} end);
+setup_meck(remove_users_on_nodes) ->
+    meck:expect(amoc_dist, remove, fun(10, false, [node1@host1, node2@host2]) -> {ok, mocked} end);
+setup_meck(update_settings) ->
+    meck:expect(amoc_dist, update_settings,
+                fun(Settings) ->
+                        ?assertEqual(lists:sort(Settings), lists:sort(settings())),
+                        {ok, mocked}
+                end);
+setup_meck(update_settings_on_nodes) ->
+    meck:expect(amoc_dist, update_settings,
+                fun(Settings, [node1@host1, node2@host2]) ->
+                        ?assertEqual(lists:sort(Settings), lists:sort(settings())),
+                        {ok, mocked}
+                end);
+setup_meck(_TC) ->
+    ok.
+
+%% Test cases
+
+start_scenario(_Config) ->
+    RequestBody = jiffy:encode({[{scenario, sample_test}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/start", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+start_scenario_with_users_and_settings(_Config) ->
+    RequestBody = jiffy:encode({[{scenario, sample_test},
+                                 {users, 10},
+                                 {settings, settings_for_json()}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/start", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+fail_to_start_non_existing_scenario(_Config) ->
+    RequestBody = jiffy:encode({[{scenario, bad_scenario}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/start", RequestBody),
+    ?assertEqual(409, HttpCode).
+
+fail_to_start_scenario_without_name(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/start", RequestBody),
+    ?assertEqual(400, HttpCode).
+
+stop_scenario(_Config) ->
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/stop", <<>>),
+    ?assertEqual(200, HttpCode).
+
+fail_to_stop_scenario_when_not_running(_Config) ->
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/stop", <<>>),
+    ?assertEqual(409, HttpCode).
+
+add_users(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/add_users", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+add_users_on_nodes(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}, {nodes, [node1@host1, node2@host2]}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/add_users", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+fail_to_add_users_when_not_running(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/add_users", RequestBody),
+    ?assertEqual(409, HttpCode).
+
+remove_users(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/remove_users", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+remove_users_on_nodes(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}, {nodes, [node1@host1, node2@host2]}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/remove_users", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+fail_to_remove_users_when_not_running(_Config) ->
+    RequestBody = jiffy:encode({[{users, 10}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/remove_users", RequestBody),
+    ?assertEqual(409, HttpCode).
+
+update_settings(_Config) ->
+    RequestBody = jiffy:encode({[{settings, settings_for_json()}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/update_settings", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+update_settings_on_nodes(_Config) ->
+    RequestBody = jiffy:encode({[{settings, settings_for_json()},
+                                 {nodes, [node1@host1, node2@host2]}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/update_settings", RequestBody),
+    ?assertEqual(200, HttpCode).
+
+fail_to_update_settings_when_not_running(_Config) ->
+    RequestBody = jiffy:encode({[{settings, settings_for_json()}]}),
+    {HttpCode, _Body} = amoc_api_helper:patch("/execution/update_settings", RequestBody),
+    ?assertEqual(409, HttpCode).
+
+%% Test helpers
+
+sample_scenario_path() ->
+    "/execution/start/sample_test".
+
+dummy_scenario_module() ->
+    ?DUMMY_SCENARIO_MODULE(sample_test).
+
+settings_for_json() ->
+    {[{some_map, <<"#{a=>b}">>},
+      {some_list, <<"[a, b, c]">>},
+      {some_tuple, <<"{a, b, c}">>},
+      {some_string, <<"\"aaa\"">>},
+      {some_binary, <<"<<\"bbb\">>">>},
+      {some_atom, <<"'ATOM'">>},
+      {some_int, <<"4">>},
+      {some_float, <<"4.6">>}]}.
+
+settings() ->
+    [{some_map, #{a => b}},
+     {some_list, [a, b, c]},
+     {some_tuple, {a, b, c}},
+     {some_string, "aaa"},
+     {some_binary, <<"bbb">>},
+     {some_atom, 'ATOM'},
+     {some_int, 4},
+     {some_float, 4.6}].

--- a/test/amoc_api_scenario_handler_SUITE.erl
+++ b/test/amoc_api_scenario_handler_SUITE.erl
@@ -17,11 +17,7 @@
          get_scenario_status_returns_404_when_scenario_not_exists/1,
          get_scenario_status_returns_running_when_scenario_is_running/1,
          get_scenario_status_returns_finished_when_scenario_is_ended/1,
-         get_scenario_status_returns_loaded_when_scenario_exists_but_not_running/1,
-         patch_scenario_returns_404_when_scenario_not_exists/1,
-         patch_scenario_returns_400_when_malformed_request/1,
-         patch_scenario_returns_200_when_request_ok_and_module_exists/1,
-         patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings/1
+         get_scenario_status_returns_loaded_when_scenario_exists_but_not_running/1
         ]).
 
 
@@ -30,11 +26,7 @@ all() ->
      get_scenario_status_returns_404_when_scenario_not_exists,
      get_scenario_status_returns_running_when_scenario_is_running,
      get_scenario_status_returns_finished_when_scenario_is_ended,
-     get_scenario_status_returns_loaded_when_scenario_exists_but_not_running,
-     patch_scenario_returns_404_when_scenario_not_exists,
-     patch_scenario_returns_400_when_malformed_request,
-     patch_scenario_returns_200_when_request_ok_and_module_exists,
-     patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings
+     get_scenario_status_returns_loaded_when_scenario_exists_but_not_running
     ].
 
 init_per_testcase(TC, Config)
@@ -95,75 +87,6 @@ get_scenario_status_returns_loaded_when_scenario_exists_but_not_running(_Config)
     ?assertMatch({[{<<"scenario_status">>, <<"loaded">>}]}, Body),
     %% cleanup
     cleanup_test_status_mock().
-
-patch_scenario_returns_404_when_scenario_not_exists(_Config) ->
-    %% given
-    RequestBody = jiffy:encode({[{users, 30}]}),
-    %% when
-    {CodeHttp, _Body} = amoc_api_helper:patch(
-                            ?SAMPLE_BAD_SCENARIO_PATH, RequestBody),
-    %% then
-    %% Maybe check Body, as answer format will be ready
-    ?assertEqual(404, CodeHttp).
-
-patch_scenario_returns_400_when_malformed_request(_Config) ->
-    %% given
-    RequestBody = jiffy:encode({[{bad_key, bad_value}]}),
-    %% when
-    {CodeHttp, _Body} = amoc_api_helper:patch(
-                            ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
-    %% then
-    %% Maybe check Body, as answer format will be ready
-    ?assertEqual(400, CodeHttp).
-
-
-patch_scenario_returns_200_when_request_ok_and_module_exists_w_settings(_Config) ->
-    %% given
-    RequestBody = jiffy:encode({[{users, 10},
-                                 {settings, {[
-                                                 {some_map, <<"#{a=>b}">>},
-                                                 {some_list, <<"[a, b, c]">>},
-                                                 {some_tuple, <<"{a, b, c}">>},
-                                                 {some_string, <<"\"aaa\"">>},
-                                                 {some_binary, <<"<<\"bbb\">>">>},
-                                                 {some_atom, <<"'ATOM'">>},
-                                                 {some_int, <<"4">>},
-                                                 {some_float, <<"4.6">>}
-                                             ]}}]}),
-    %% when
-    {CodeHttp, _Body} = amoc_api_helper:patch(
-        ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
-
-    Predicate = fun(S) ->
-                    Settings = [{some_map, #{a => b}},
-                                {some_list, [a, b, c]},
-                                {some_tuple, {a, b, c}},
-                                {some_string, "aaa"},
-                                {some_binary, <<"bbb">>},
-                                {some_atom, 'ATOM'},
-                                {some_int, 4},
-                                {some_float, 4.6}],
-                    ?assertEqual(lists:sort(S), lists:sort(Settings)),
-                    true
-                end,
-    SettingsMatcher = meck_matcher:new(Predicate),
-    %% then
-    %% Maybe check Body, as answer format will be ready
-    meck:wait(amoc_dist, do, [?SAMPLE_SCENARIO, 10, SettingsMatcher], 2000),
-    ?assertEqual(200, CodeHttp).
-
-patch_scenario_returns_200_when_request_ok_and_module_exists(_Config) ->
-    %% given
-    RequestBody = jiffy:encode({[{users, 10}]}),
-    %% when
-    {CodeHttp, _Body} = amoc_api_helper:patch(
-        ?SAMPLE_GOOD_SCENARIO_PATH, RequestBody),
-
-    %% then
-    %% Maybe check Body, as answer format will be ready
-    meck:wait(amoc_dist, do, [?SAMPLE_SCENARIO, 10, []], 2000),
-    ?assertEqual(200, CodeHttp).
-
 
 %% Helpers
 


### PR DESCRIPTION
Follows the API definition: https://github.com/esl/amoc_rest/blob/1d615924/openapi.yaml

- Added and tested the new REST API endpoints
- Added support for `update_settings` in `amoc_dist`
- Fixed some minor issues with type specs

There is an increasing need to add tests for `amoc_dist` - this module is untested. This should be done in a separate issue.

See the commit messages below for more details.

