### PR TITLE
Amoc config env cleanup

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,6 @@
 ## Configuration
 
-Amoc is configured through the environment variables (uppercase with prefix ``AMOC_``).
+Amoc is configured through environment variables (uppercase with prefix ``AMOC_``).
 Note that the environment variables are evaluated as erlang code
 
 Amoc supports the following generic configuration parameters:
@@ -17,23 +17,17 @@ Amoc supports the following generic configuration parameters:
   for two consecutive users:
     * default value - 50 ms.
     * example: `AMOC_INTERARRIVAL="50"`
-    * this parameter can be updated runtime (in the same way as scenario configuration).
+    * this parameter can be updated at runtime (in the same way as scenario configuration).
 
 * ``extra_code_paths`` - a list of paths that should be included using `code:add_pathsz/1` interface
     * default value - empty list (`[]`)
     * example: `AMOC_EXTRA_CODE_PATHS='["/some/path", "/another/path"]'`
 
-In addition to that, `amoc_metrics` support the following configuration parameters:
-
-* ``metrics_reporter`` - exometer reporter name (atom).
-    * default value - `exometer_report_graphite`
-    * example: `AMOC_METRICS_REPORTER="exometer_report_graphite"`
-
-If the ``metrics_reporter`` is not initialised, it's possible to configure a Graphite reporter
+In addition to that, `amoc_metrics` allow to configure a Graphite reporter
 using the following environment variables:
 
 * ``graphite_host`` - a graphite host address (string or `undefined`):
-    * default value - `undefined` (amoc_metrics do not try to initialise a ``metrics_reporter``)
+    * default value - `undefined` (amoc_metrics do not try to initialise a metrics reporter)
     * example: `AMOC_GRAPHITE_HOST='"graphite"'`
 
 * ``graphite_port`` - graphite port:
@@ -57,7 +51,7 @@ parameters required for your scenario, however every scenario must declare (usin
 `-required_variable(...)` attributes) all the required parameters in advance. For more
 information, see the example [scenario module](../integration_test/dummy_scenario.erl)
 
-Scenario configuration also can be set/updated runtime using REST API.
+Scenario configuration also can be set/updated at runtime using REST API.
 
 NB: the reason why the `-required_variable(...)` is preferred over the usual behaviour
 callback is because the orchestration tools can easily extract the attributes even

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,56 +1,48 @@
 ## Configuration
 
-Amoc is configured through the OTP application environment variables that
-can be set in the `app.config` configuration file (see [rebar3 documentation](https://www.rebar3.org/docs/releases#section-overlays))
-or using the operating system environment variables (uppercase with prefix ``AMOC_``). Note that the operating system environment variables are evaluated as erlang code
+Amoc is configured through the environment variables (uppercase with prefix ``AMOC_``).
+Note that the environment variables are evaluated as erlang code
 
 Amoc supports the following generic configuration parameters:
 
 * ``nodes`` - required for the distributed scenario execution, a list of nodes that should be clustered together:
     * default value - empty list (`[]`)
-    * os env example: `AMOC_NODES="['amoc@amoc-1', 'amoc@amoc-2']"`
-    * app.config example:  `{nodes,  ['amoc@amoc-1', 'amoc@amoc-2]}`                                  
+    * example: `AMOC_NODES="['amoc@amoc-1', 'amoc@amoc-2']"`
 
 * ``api_port`` - a port for the amoc REST interfaces:
     * default value - 4000
-    * os env example: `AMOC_API_PORT="4000"`
-    * app.config example:  `{api_port, 4000}`
+    * example: `AMOC_API_PORT="4000"`
                                       
 * ``interarrival`` - a delay (in ms, for each node in the cluster independently) between creating the processes
   for two consecutive users:
     * default value - 50 ms.
-    * os env example: `AMOC_INTERARRIVAL="50"`
-    * app.config example:  `{interarrival, 50}`
+    * example: `AMOC_INTERARRIVAL="50"`
+    * this parameter can be updated runtime (in the same way as scenario configuration).
 
 * ``extra_code_paths`` - a list of paths that should be included using `code:add_pathsz/1` interface
     * default value - empty list (`[]`)
-    * os env example: `AMOC_EXTRA_CODE_PATHS='["/some/path", "/another/path"]'`
-    * app.config example:  `{extra_code_paths, ["/some/path", "/another/path"]}`
+    * example: `AMOC_EXTRA_CODE_PATHS='["/some/path", "/another/path"]'`
 
 In addition to that, `amoc_metrics` support the following configuration parameters:
 
 * ``metrics_reporter`` - exometer reporter name (atom).
     * default value - `exometer_report_graphite`
-    * os env example: `AMOC_METRICS_REPORTER="exometer_report_graphite"`
-    * app.config example:  `{metrics_reporter, exometer_report_graphite}`
+    * example: `AMOC_METRICS_REPORTER="exometer_report_graphite"`
 
 If the ``metrics_reporter`` is not initialised, it's possible to configure a Graphite reporter
 using the following environment variables:
 
 * ``graphite_host`` - a graphite host address (string or `undefined`):
     * default value - `undefined` (amoc_metrics do not try to initialise a ``metrics_reporter``)
-    * os env example: `AMOC_GRAPHITE_HOST='"graphite"'`
-    * app.config example:  `{graphite_host, "graphite"}`
+    * example: `AMOC_GRAPHITE_HOST='"graphite"'`
 
 * ``graphite_port`` - graphite port:
     * default value - `2003`
-    * os env example: `AMOC_GRAPHITE_PORT='2003'`
-    * app.config example:  `{graphite_port, 2003}`    
+    * example: `AMOC_GRAPHITE_PORT='2003'`
     
 * ``graphite_prefix`` - graphite prefix:
     * default value - `net_adm:localhost()`
-    * os env example: `AMOC_GRAPHITE_PREFIX='"amoc"'`
-    * app.config example:  `{graphite_prefix, "amoc"}`    
+    * example: `AMOC_GRAPHITE_PREFIX='"amoc"'`
 
 In order to initialise some preconfigured metrics, other applications can declare
 the `predefined_metrics` environment variable (in their own `*.app.src` file):  
@@ -65,6 +57,7 @@ parameters required for your scenario, however every scenario must declare (usin
 `-required_variable(...)` attributes) all the required parameters in advance. For more
 information, see the example [scenario module](../integration_test/dummy_scenario.erl)
 
+Scenario configuration also can be set/updated runtime using REST API.
 
 NB: the reason why the `-required_variable(...)` is preferred over the usual behaviour
 callback is because the orchestration tools can easily extract the attributes even

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -9,21 +9,20 @@
 %%==============================================================================
 -module(amoc_config_env).
 
--export([get/2, get/3, parse_value/1, find_all_vars/1]).
+-export([get/1, get/2, parse_value/1, find_all_vars/1]).
 
 -include_lib("kernel/include/logger.hrl").
 
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------
--spec get(atom(), amoc_config:name()) -> amoc_config:value().
-get(AppName, Name) ->
-    get(AppName, Name, undefined).
+-spec get(amoc_config:name()) -> amoc_config:value().
+get(Name) ->
+    get(Name, undefined).
 
--spec get(atom(), amoc_config:name(), amoc_config:value()) -> amoc_config:value().
-get(AppName, Name, Default) when is_atom(Name) ->
-    DefValue = application:get_env(AppName, Name, Default),
-    get_os_env(Name, DefValue).
+-spec get(amoc_config:name(), amoc_config:value()) -> amoc_config:value().
+get(Name, Default) when is_atom(Name) ->
+    get_os_env(Name, Default).
 
 -spec parse_value(string() | binary()) -> {ok, amoc_config:value()} | {error, any()}.
 parse_value(Binary) when is_binary(Binary) ->

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -9,7 +9,7 @@
 %%==============================================================================
 -module(amoc_config_env).
 
--export([get/1, get/2, parse_value/1, find_all_vars/1]).
+-export([get/1, get/2, parse_value/1]).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -34,12 +34,6 @@ parse_value(String) when is_list(String) ->
     catch
         _:E -> {error, E}
     end.
-
--spec find_all_vars(atom()) -> [any()].
-find_all_vars(Name) ->
-    AllValues = [application:get_env(App, Name)
-                 || {App, _, _} <- application:loaded_applications()],
-    [Value || {ok, Value} <- AllValues].
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/amoc_config/amoc_config_utils.erl
+++ b/src/amoc_config/amoc_config_utils.erl
@@ -12,7 +12,8 @@
          merge_config/2,
          override_config/2,
          store_scenario_config/1,
-         create_amoc_config_ets/0]).
+         create_amoc_config_ets/0,
+         find_all_vars/1]).
 
 -spec maybe_error(error_type(), [{error, reason()} | {ok, any()}]) ->
     error() | {ok, [any()]}.
@@ -71,3 +72,9 @@ create_amoc_config_ets() ->
                                         protected,
                                         {keypos, #module_parameter.name},
                                         {read_concurrency, true}]).
+
+-spec find_all_vars(atom()) -> [any()].
+find_all_vars(Name) ->
+    AllValues = [application:get_env(App, Name)
+                 || {App, _, _} <- application:loaded_applications()],
+    [Value || {ok, Value} <- AllValues].

--- a/src/amoc_config/amoc_config_verification.erl
+++ b/src/amoc_config/amoc_config_verification.erl
@@ -24,8 +24,7 @@ process_scenario_config(Config, Settings) ->
 get_value_and_verify(#module_parameter{name = Name, mod = Module, value = Default,
                                        verification_fn = VerificationFn} = Param,
                      Settings) ->
-    App = get_application(Module),
-    DefaultValue = amoc_config_env:get(App, Name, Default),
+    DefaultValue = amoc_config_env:get(Name, Default),
     Value = proplists:get_value(Name, Settings, DefaultValue),
     case verify(VerificationFn, Value) of
         {true, NewValue} ->
@@ -50,11 +49,4 @@ verify(Fun, Value) ->
             ?LOG_ERROR("invalid verification method ~p(~p), exception: ~p ~p ~p",
                        [Fun, Value, C, E, S]),
             {false, {exception_during_verification, {C, E, S}}}
-    end.
-
--spec get_application(module()) -> atom().
-get_application(Module) ->
-    case application:get_application(Module) of
-        undefined -> amoc;
-        {ok, App} -> App
     end.

--- a/src/amoc_distribution/amoc_cluster.erl
+++ b/src/amoc_distribution/amoc_cluster.erl
@@ -51,7 +51,7 @@
 %% ------------------------------------------------------------------
 -spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
-    Nodes = amoc_config_env:get(amoc, nodes, []),
+    Nodes = amoc_config_env:get(nodes, []),
     gen_server:start_link({local, ?SERVER}, ?MODULE, Nodes, []).
 
 -spec connect_nodes([node()]) -> ok.

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -118,5 +118,5 @@ maybe_subscribe(ExName, Datapoints) ->
     end.
 
 maybe_init_predefined_metrics() ->
-    Preconfigured = amoc_config_env:find_all_vars(predefined_metrics),
+    Preconfigured = amoc_config_utils:find_all_vars(predefined_metrics),
     [init(Type, Name) || {Type, Name} <- lists:flatten(Preconfigured)].

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -83,11 +83,11 @@ maybe_add_reporter() ->
     case lists:keyfind(Reporter, 1, exometer_report:list_reporters()) of
         {Reporter, _} -> ok;
         _->
-            case amoc_config_env:get(amoc, graphite_host) of
+            case amoc_config_env:get(graphite_host) of
                 undefined -> ok;
                 Host ->
-                    Prefix = amoc_config_env:get(amoc, graphite_prefix, net_adm:localhost()),
-                    Port = amoc_config_env:get(amoc, graphite_port, 2003),
+                    Prefix = amoc_config_env:get(graphite_prefix, net_adm:localhost()),
+                    Port = amoc_config_env:get(graphite_port, 2003),
                     Options = [{module, exometer_report_graphite},
                                {prefix, Prefix},
                                {host, Host},
@@ -103,7 +103,8 @@ subsribe_default_metrics() ->
     maybe_subscribe([erlang, memory], [total, processes, processes_used, system, binary, ets]).
 
 get_reporter() ->
-    amoc_config_env:get(amoc, metrics_reporter, ?AMOC_DEFAULT_METRICS_REPORTER).
+    App = application:get_application(?MODULE),
+    application:get_env(App, metrics_reporter, ?AMOC_DEFAULT_METRICS_REPORTER).
 
 maybe_subscribe(ExName, Datapoints) ->
     Reporter = get_reporter(),

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -97,7 +97,7 @@ start_scenarios_ets() ->
 -spec add_code_paths() -> ok | {error, {bad_directories, [file:filename()]}}.
 add_code_paths() ->
     true = code:add_pathz(?EBIN_DIR),
-    AdditionalCodePaths = amoc_config_env:get(amoc, extra_code_paths, []),
+    AdditionalCodePaths = amoc_config_env:get(extra_code_paths, []),
     Res = [{code:add_pathz(Path), Path} || Path <- [?EBIN_DIR | AdditionalCodePaths]],
     case [Dir || {{error, bad_directory}, Dir} <- Res] of
         [] -> ok;

--- a/src/rest_api/amoc_api.erl
+++ b/src/rest_api/amoc_api.erl
@@ -9,7 +9,7 @@
 -spec start() -> {ok, pid()} | {error, any()}.
 start() ->
     LogicHandler = amoc_api_logic_handler,
-    Port = amoc_config_env:get(amoc, api_port, 4000),
+    Port = amoc_config_env:get(api_port, 4000),
     ServerParams = #{ip => {0, 0, 0, 0}, port => Port, net_opts => [],
                      logic_handler => LogicHandler},
     amoc_rest_server:start(http_server, ServerParams).

--- a/test/amoc_api_helper.erl
+++ b/test/amoc_api_helper.erl
@@ -82,5 +82,5 @@ request(BaseUrl, Path, Method, RequestBody, ContentType) ->
 
 -spec get_url() -> string().
 get_url() ->
-    Port = amoc_config_env:get(amoc, api_port, 4000),
+    Port = amoc_config_env:get(api_port, 4000),
     "http://localhost:" ++ erlang:integer_to_list(Port).

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -4,22 +4,16 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -import(amoc_config_helper, [format_value/1,
+                             get_env/1,
                              get_env/2,
-                             get_env/3,
                              set_os_env/2,
-                             unset_os_env/1,
-                             set_app_env/3,
-                             unset_app_env/2]).
+                             unset_os_env/1]).
 
 -compile(export_all).
 
--define(APP, common_test).
-
 all() ->
     [parse_value_prop_test,
-     config_os_env_test,
-     config_app_env_test,
-     config_os_env_shadows_app_env_test].
+     config_os_env_test].
 
 parse_value_prop_test(_) ->
     RealAnyType = weighted_union([{1, map(any(), any())},
@@ -29,43 +23,15 @@ parse_value_prop_test(_) ->
     ?assertEqual(true, proper:quickcheck(ProperTest, [quiet])).
 
 config_os_env_test(_) ->
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
+    unset_os_env(some_variable),
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)),
     set_os_env(some_variable, some_value),
-    ?assertEqual(some_value, get_env(?APP, some_variable)),
-    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
+    ?assertEqual(some_value, get_env(some_variable)),
+    ?assertEqual(some_value, get_env(some_variable, default_value)),
     set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(?APP, some_variable)),
-    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
+    ?assertEqual(another_value, get_env(some_variable)),
+    ?assertEqual(another_value, get_env(some_variable, default_value)),
     unset_os_env(some_variable),
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).
-
-config_app_env_test(_) ->
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
-    set_app_env(?APP, some_variable, some_value),
-    ?assertEqual(some_value, get_env(?APP, some_variable)),
-    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
-    set_app_env(?APP, some_variable, another_value),
-    ?assertEqual(another_value, get_env(?APP, some_variable)),
-    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
-    unset_app_env(?APP, some_variable),
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).
-
-config_os_env_shadows_app_env_test(_) ->
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)),
-    set_app_env(?APP, some_variable, some_value),
-    ?assertEqual(some_value, get_env(?APP, some_variable)),
-    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
-    set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(?APP, some_variable)),
-    ?assertEqual(another_value, get_env(?APP, some_variable, default_value)),
-    unset_os_env(some_variable),
-    ?assertEqual(some_value, get_env(?APP, some_variable)),
-    ?assertEqual(some_value, get_env(?APP, some_variable, default_value)),
-    unset_app_env(?APP, some_variable),
-    ?assertEqual(undefined, get_env(?APP, some_variable)),
-    ?assertEqual(default_value, get_env(?APP, some_variable, default_value)).
+    ?assertEqual(undefined, get_env(some_variable)),
+    ?assertEqual(default_value, get_env(some_variable, default_value)).

--- a/test/amoc_config_helper.erl
+++ b/test/amoc_config_helper.erl
@@ -2,12 +2,6 @@
 
 -compile(export_all).
 
-set_app_env(App, Name, Value) ->
-    application:set_env(App, Name, Value).
-
-unset_app_env(App, Name) ->
-    application:unset_env(App, Name).
-
 set_os_env(Name, Value) ->
     os:putenv(env_name(Name), format_value(Value)).
 
@@ -17,11 +11,11 @@ unset_os_env(Name) ->
 env_name(Name) ->
     "AMOC_" ++ string:uppercase(erlang:atom_to_list(Name)).
 
-get_env(App, Name) ->
-    amoc_config_env:get(App, Name).
+get_env(Name) ->
+    amoc_config_env:get(Name).
 
-get_env(App, Name, Default) ->
-    amoc_config_env:get(App, Name, Default).
+get_env(Name, Default) ->
+    amoc_config_env:get(Name, Default).
 
 format_value(Value) ->
     lists:flatten(io_lib:format("~tp", [Value])).


### PR DESCRIPTION
removing possibility to provide configuration parameters values via erlang app env. variables.

this is a legacy functionality that rather increases the complexity than provides any benefits, it became confusing after splitting up amoc/scenarios/helpers into several erlang applications.