### PR TITLE
Do not use process priority max as per OTP guidelines

### DIFF
--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -126,16 +126,21 @@ maybe_update_interarrival_timer(interarrival, _) ->
 %% ------------------------------------------------------------------
 -spec init([]) -> {ok, state()}.
 init([]) ->
-    process_flag(priority, max),
     start_tables(),
     {ok, #state{}}.
 
+%% We set the priority to high after starting the scenario,
+%% and then reset priority to normal after terminating it.
+%% The most important part is precise timing for users spawning/removal,
+%% so priority is higher in between init and terminate.
 -spec handle_call(any(), any(), state()) -> {reply, handle_call_res(), state()}.
 handle_call({start_scenario, Scenario, Settings}, _From, State) ->
     {RetValue, NewState} = handle_start_scenario(Scenario, Settings, State),
+    process_flag(priority, high),
     {reply, RetValue, NewState};
 handle_call(stop_scenario, _From, State) ->
     {RetValue, NewState} = handle_stop_scenario(State),
+    process_flag(priority, normal),
     {reply, RetValue, NewState};
 handle_call({update_settings, Settings}, _From, State) ->
     RetValue = handle_update_settings(Settings, State),

--- a/src/amoc_users_sup.erl
+++ b/src/amoc_users_sup.erl
@@ -47,10 +47,8 @@ stop_children(Pids, true) ->
 
 -spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
-    process_flag(priority, max),
-
+    process_flag(priority, high),
     SupFlags = #{strategy => simple_one_for_one},
-
     AChild = #{id => amoc_user,
                start => {amoc_user, start_link, []},
                %% A temporary child process is never restarted


### PR DESCRIPTION
As described in https://www.erlang.org/doc/man/erlang.html#process_flag_priority
> Priority level max is reserved for internal use in the Erlang runtime system, and is not to be used by others.