### PR TITLE
Configurable env parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default rel compile clean ct test integration_test dialyzer xref console
+.PHONY: default rel compile clean ct test integration_test dialyzer xref console lint
 
 REBAR = rebar3
 
@@ -25,7 +25,10 @@ ct:
 	## eunit and ct commands always add a test profile to the run
 	$(REBAR) ct --verbose $(SUITE_OPTS)
 
-test: compile xref dialyzer ct
+lint:
+	$(REBAR) as elvis lint
+
+test: compile xref dialyzer ct lint
 
 integration_test:
 	./integration_test/stop_demo_cluster.sh

--- a/elvis.config
+++ b/elvis.config
@@ -1,0 +1,28 @@
+[{elvis, [
+    {config, [
+        #{dirs => ["src", "src/*", "scenarios"],
+          filter => "*.erl",
+          ruleset => erl_files,
+          rules => [
+              {elvis_style, invalid_dynamic_call, #{ignore => [amoc_user]}},
+              {elvis_style, export_used_types, disable},
+              {elvis_style, no_throw, #{ignore => [{amoc_config, get, 2}] }},
+              {elvis_text_style, line_length, #{skip_comments => whole_line }},
+              {elvis_style, no_block_expressions, disable}
+          ]},
+        #{dirs => ["test"],
+          filter => "*.erl",
+          ruleset => erl_files,
+          rules => [
+              {elvis_style, function_naming_convention, #{regex => "^[a-z]([a-z0-9]*_?)*$"}},
+              {elvis_style, atom_naming_convention, #{regex => "^[a-z]([a-z0-9]*_?)*(_SUITE)?$"}},
+              {elvis_style, dont_repeat_yourself, #{min_complexity => 50}},
+              {elvis_style, no_debug_call, disable},
+              {elvis_style, no_throw, disable},
+              {elvis_style, no_import, disable}
+          ]},
+        #{dirs => ["."],
+          filter => "rebar.config",
+          ruleset => rebar_config}
+    ]}
+]}].

--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,7 @@
             {fusco, "0.1.1"}
         ]}
     ]},
+    {elvis, [{plugins, [{rebar3_lint, "3.0.1"}]}]},
     {demo, [
         {erl_opts, [debug_info, {src_dirs, ["src", "scenarios"]}]},
         {relx, [

--- a/src/amoc_config/amoc_config.hrl
+++ b/src/amoc_config/amoc_config.hrl
@@ -46,8 +46,9 @@
 -type maybe_module_config() :: {ok, [module_parameter()]} | error().
 
 -type one_of() :: [value(), ...].
--type verification_method() :: none | one_of() | {module(), atom(), 1}.
--type update_method() :: read_only | none | {module(), atom(), 2}.
+-type mfa(Arity) :: {module(), atom(), Arity}.
+-type verification_method() :: none | one_of() | mfa(1) | verification_fun().
+-type update_method() :: read_only | none | mfa(2) | update_fun().
 
 -type module_attribute() :: #{ name := name(),
                                description := string(),

--- a/src/amoc_config/amoc_config_attributes.erl
+++ b/src/amoc_config/amoc_config_attributes.erl
@@ -127,8 +127,8 @@ make_module_parameter(#{name := Name, description := Description, default_value 
     maybe_verification_fun() | not_exported | invalid_method.
 verification_fn(none) ->
     fun ?MODULE:none/1;
-verification_fn([_ | _] = OneOF) ->
-    one_of_fun(OneOF);
+verification_fn([_ | _] = OneOf) ->
+    one_of_fun(OneOf);
 verification_fn(Fun) when is_function(Fun, 1) ->
     is_exported(Fun);
 verification_fn({Module, Function, 1}) ->

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -60,8 +60,8 @@ parse_value(String, _) ->
     try Mod:parse_value(String) of
         {ok, Value} -> {ok, Value};
         {error, Error} -> {error, Error};
-        InvalidRetValue -> {error,{parser_returned_invalid_value, InvalidRetValue}}
+        InvalidRetValue -> {error, {parser_returned_invalid_value, InvalidRetValue}}
     catch
         Class:Error:Stacktrace ->
-            {error,{parser_crashed, {Class, Error, Stacktrace}}}
+            {error, {parser_crashed, {Class, Error, Stacktrace}}}
     end.

--- a/src/amoc_config/amoc_config_env.erl
+++ b/src/amoc_config/amoc_config_env.erl
@@ -9,9 +9,13 @@
 %%==============================================================================
 -module(amoc_config_env).
 
--export([get/1, get/2, parse_value/1, format/2]).
+-export([get/1, get/2]).
 
 -include_lib("kernel/include/logger.hrl").
+
+-define(DEFAULT_PARSER_MODULE, amoc_config_parser).
+
+-callback(parse_value(string()) -> {ok, amoc_config:value()} | {error, any()}).
 
 %% ------------------------------------------------------------------
 %% API
@@ -24,24 +28,6 @@ get(Name) ->
 get(Name, Default) when is_atom(Name) ->
     get_os_env(Name, Default).
 
--spec parse_value(string() | binary()) -> {ok, amoc_config:value()} | {error, any()}.
-parse_value(Binary) when is_binary(Binary) ->
-    parse_value(binary_to_list(Binary));
-parse_value(String) when is_list(String) ->
-    try
-        {ok, Tokens, _} = erl_scan:string(String ++ "."),
-        {ok, _} = erl_parse:parse_term(Tokens)
-    catch
-        _:E -> {error, E}
-    end.
-
--spec format(any(), binary) -> binary();
-            (any(), string)  -> string().
-format(Value, binary) ->
-    list_to_binary(format(Value, string));
-format(Value, string) ->
-    lists:flatten(io_lib:format("~tp", [Value])).
-
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
@@ -51,8 +37,13 @@ get_os_env(Name, Default) ->
     Value = os:getenv(EnvName),
     case parse_value(Value, Default) of
         {ok, Term} -> Term;
-        {error, _} ->
-            ?LOG_ERROR("cannot parse $~p value \"~p\", using default one", [EnvName, Value]),
+        {error, Error} ->
+            ?LOG_ERROR("cannot parse environment variable, using default value.~n"
+                          "  parsing error:  '~p'~n"
+                          "  variable name:  '$~s'~n"
+                          "  variable value: '~s'~n"
+                          "  default value:  '~p'~n",
+                       [Error, EnvName, Value, Default]),
             Default
     end.
 
@@ -64,4 +55,13 @@ os_env_name(Name) when is_atom(Name) ->
 parse_value(false, Default) -> {ok, Default};
 parse_value("", Default)    -> {ok, Default};
 parse_value(String, _) ->
-    parse_value(String).
+    App = application:get_application(?MODULE),
+    Mod = application:get_env(App, config_parser_mod, ?DEFAULT_PARSER_MODULE),
+    try Mod:parse_value(String) of
+        {ok, Value} -> {ok, Value};
+        {error, Error} -> {error, Error};
+        InvalidRetValue -> {error,{parser_returned_invalid_value, InvalidRetValue}}
+    catch
+        Class:Error:Stacktrace ->
+            {error,{parser_crashed, {Class, Error, Stacktrace}}}
+    end.

--- a/src/amoc_config/amoc_config_parser.erl
+++ b/src/amoc_config/amoc_config_parser.erl
@@ -1,0 +1,40 @@
+%%==============================================================================
+%% Copyright 2023 Erlang Solutions Ltd.
+%% Licensed under the Apache License, Version 2.0 (see LICENSE file)
+%%==============================================================================
+%% This module implements the default parser for the amoc_config_env module
+%%==============================================================================
+-module(amoc_config_parser).
+-behaviour(amoc_config_env).
+
+-export([parse_value/1]).
+
+-ifdef(TEST).
+%% exported for testing only
+-export([format/2]).
+-else.
+-ignore_xref([format/2]).
+-dialyzer({nowarn_function, [format/2]}).
+-endif.
+
+%% ------------------------------------------------------------------
+%% API
+%% ------------------------------------------------------------------
+
+-spec parse_value(string() | binary()) -> {ok, amoc_config:value()} | {error, any()}.
+parse_value(Binary) when is_binary(Binary) ->
+    parse_value(binary_to_list(Binary));
+parse_value(String) when is_list(String) ->
+    try
+        {ok, Tokens, _} = erl_scan:string(String ++ "."),
+        {ok, _} = erl_parse:parse_term(Tokens)
+    catch
+        _:E -> {error, E}
+    end.
+
+-spec format(any(), binary) -> binary();
+            (any(), string)  -> string().
+format(Value, binary) ->
+    list_to_binary(format(Value, string));
+format(Value, string) ->
+    lists:flatten(io_lib:format("~tp", [Value])).

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -95,10 +95,10 @@ update_settings(Settings) ->
 
 -spec add_users(amoc_scenario:user_id(), amoc_scenario:user_id()) ->
     ok | {error, term()}.
-add_users(StartId, EndID) ->
-    telemetry:execute([amoc, controller, users], #{count => EndID - StartId + 1}, #{type => add}),
+add_users(StartId, EndId) ->
+    telemetry:execute([amoc, controller, users], #{count => EndId - StartId + 1}, #{type => add}),
     %% adding the exact range of the users
-    gen_server:call(?SERVER, {add, StartId, EndID}).
+    gen_server:call(?SERVER, {add, StartId, EndId}).
 
 -spec remove_users(user_count(), boolean()) -> {ok, user_count()}.
 remove_users(Count, ForceRemove) ->
@@ -145,8 +145,8 @@ handle_call(stop_scenario, _From, State) ->
 handle_call({update_settings, Settings}, _From, State) ->
     RetValue = handle_update_settings(Settings, State),
     {reply, RetValue, State};
-handle_call({add, StartId, EndID}, _From, State) ->
-    {RetValue, NewState} = handle_add(StartId, EndID, State),
+handle_call({add, StartId, EndId}, _From, State) ->
+    {RetValue, NewState} = handle_add(StartId, EndId, State),
     {reply, RetValue, NewState};
 handle_call({remove, Count, ForceRemove}, _From, State) ->
     RetValue = handle_remove(Count, ForceRemove, State),
@@ -296,13 +296,13 @@ init_scenario(Scenario, Settings) ->
         {error, Type, Reason} -> {error, {Type, Reason}}
     end.
 
--spec maybe_start_timer(timer:tref()|undefined) -> timer:tref().
+-spec maybe_start_timer(timer:tref() | undefined) -> timer:tref().
 maybe_start_timer(undefined) ->
     {ok, TRef} = timer:send_interval(interarrival(), start_user),
     TRef;
 maybe_start_timer(TRef) -> TRef.
 
--spec maybe_stop_timer(timer:tref()|undefined) -> undefined.
+-spec maybe_stop_timer(timer:tref() | undefined) -> undefined.
 maybe_stop_timer(undefined) ->
     undefined;
 maybe_stop_timer(TRef) ->

--- a/src/amoc_coordinator/amoc_coordinator.erl
+++ b/src/amoc_coordinator/amoc_coordinator.erl
@@ -86,7 +86,8 @@ start(Name, CoordinationPlan, Timeout) when ?IS_TIMEOUT(Timeout) ->
             %% end, we need to add them first.
             AllItemsHandlers = lists:reverse([Item || {all, _} = Item <- Plan]),
             [gen_event:add_handler(Name, ?MODULE, {Name, Item}) || Item <- AllItemsHandlers],
-            [gen_event:add_handler(Name, ?MODULE, {Name, Item}) || {N, _} = Item <- Plan, is_integer(N)],
+            [gen_event:add_handler(Name, ?MODULE, {Name, Item}) || {N, _} = Item <- Plan,
+                                                                   is_integer(N)],
             gen_event:add_handler(Name, ?MODULE, {timeout, Name, Timeout}),
             ok;
         {error, _} -> error

--- a/src/amoc_distribution/amoc_cluster.erl
+++ b/src/amoc_distribution/amoc_cluster.erl
@@ -168,9 +168,11 @@ connect_nodes(Node, Nodes) ->
 set_master_node(Node, Action) ->
     case gen_server:call({?SERVER, Node}, {set_master_node, node()}) of
         ok ->
-            case catch apply(Action, [Node]) of
+            try apply(Action, [Node]) of
                 ok -> gen_server:cast(?SERVER, {add_slave, Node});
                 RetValue -> {error, {invalid_action_ret_value, RetValue}}
+            catch
+                C:E:S -> {error, {invalid_action_ret_value, {C, E, S}}}
             end;
         Error -> Error
     end.

--- a/src/amoc_distribution/amoc_dist.erl
+++ b/src/amoc_distribution/amoc_dist.erl
@@ -16,7 +16,7 @@
 
 -compile({no_auto_import, [ceil/1]}).
 
--type cluster_state():: idle | running | stopped.
+-type cluster_state() :: idle | running | stopped.
 %% ------------------------------------------------------------------
 %% API
 %% ------------------------------------------------------------------

--- a/src/amoc_throttle/amoc_throttle.erl
+++ b/src/amoc_throttle/amoc_throttle.erl
@@ -114,7 +114,7 @@ change_rate_gradually(Name, LowRate, HighRate, RateInterval, StepInterval, NoOfS
 %%        destroy Async runner
 %%  '''
 %% for the local execution, req/exec rates are increased only by throttle process.
--spec run(name(), fun(()-> any())) -> ok | {error, any()}.
+-spec run(name(), fun(() -> any())) -> ok | {error, any()}.
 run(Name, Fn) ->
     amoc_throttle_controller:run(Name, Fn).
 

--- a/test/amoc_config_attributes_SUITE.erl
+++ b/test/amoc_config_attributes_SUITE.erl
@@ -32,6 +32,8 @@
     #{name => var7, description => "var7", default_value => def7,
       verification => none, update => {?MODULE, update_value, 2}}
 ]).
+-required_variable(#{name => var7b, description => "var7b", default_value => def7,
+                     verification => none, update => fun ?MODULE:update_value/2}).
 
 %% verification functions
 -export([verify_value/1]).
@@ -66,7 +68,9 @@ get_module_attributes(_) ->
         #{name => var6, description => "var6", default_value => def6,
           verification => none, update => none},
         #{name => var7, description => "var7", default_value => def7,
-          verification => none, update => {?MODULE, update_value, 2}}],
+          verification => none, update => {?MODULE, update_value, 2}},
+        #{name => var7b, description => "var7b", default_value => def7,
+          verification => none, update => fun ?MODULE:update_value/2}],
     ?assertEqual(ExpectedResult, Result).
 
 get_module_configuration(_) ->
@@ -95,6 +99,8 @@ get_module_configuration(_) ->
          #module_parameter{name = var6, mod = ?MODULE, value = def6,
                            verification_fn = VerificationNone, update_fn = UpdateNone},
          #module_parameter{name = var7, mod = ?MODULE, value = def7,
+                           verification_fn = VerificationNone, update_fn = UpdateValueFN},
+         #module_parameter{name = var7b, mod = ?MODULE, value = def7,
                            verification_fn = VerificationNone, update_fn = UpdateValueFN}],
         Config).
 
@@ -115,8 +121,10 @@ errors_reporting(_) ->
                       update => fun invalid_module:not_exported_function/2},
     InvalidParam7 = #{name => invalid_var7, description => "var7",
                       update => fun update_value/2}, %% local function
-    Attributes = [InvalidParam0, InvalidParam1, InvalidParam2, ValidParam3,
-                  InvalidParam4, InvalidParam4b, InvalidParam5, InvalidParam6, InvalidParam7],
+    InvalidParam7b = #{name => invalid_var7, description => "var7b",
+                      update => fun update_value/2}, %% local function
+    Attributes = [InvalidParam0, InvalidParam1, InvalidParam2, ValidParam3, InvalidParam4,
+                  InvalidParam4b, InvalidParam5, InvalidParam6, InvalidParam7, InvalidParam7b],
     {error, invalid_attribute_format, Reason} =
         amoc_config_attributes:process_module_attributes(?MODULE, Attributes),
     ?assertEqual(
@@ -127,7 +135,8 @@ errors_reporting(_) ->
          {InvalidParam4b, verification_method_not_exported},
          {InvalidParam5, invalid_update_method},
          {InvalidParam6, update_method_not_exported},
-         {InvalidParam7, update_method_not_exported}],
+         {InvalidParam7, update_method_not_exported},
+         {InvalidParam7b, update_method_not_exported}],
         Reason).
 
 one_of_function(_) ->

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -7,31 +7,125 @@
                              get_env/1,
                              get_env/2,
                              set_os_env/2,
-                             unset_os_env/1]).
+                             unset_os_env/1,
+                             set_empty_os_env/1]).
 
 -compile(export_all).
 
+-define(MOCK_MOD, custom_parser).
+
 all() ->
     [parse_value_prop_test,
-     config_os_env_test].
+     default_parser_test,
+     valid_custom_parser_test,
+     invalid_custom_parser_test].
+
+init_per_suite(Config) ->
+    %% set some predefined variables
+    set_os_env(set_var, some_value),
+    unset_os_env(unset_var),
+    set_empty_os_env(empty_var),
+    ct:pal("OS env:~n   ~p", [os:getenv()]),
+    Config.
+
+end_per_suite(_)->
+    %% unset predefined variables
+    unset_os_env(set_var),
+    unset_os_env(empty_var).
+
+init_per_testcase(valid_custom_parser_test, Config) ->
+    meck:new(?MOCK_MOD, [non_strict, no_link]),
+    App = application:get_application(amoc_config_env),
+    application:set_env(App, config_parser_mod, ?MOCK_MOD),
+    ct:pal("amoc_config_env module belongs to '~p' application", [App]),
+    ct:pal("AMOC_* OS env. variables:~n   ~p", [[AmocEnv || "AMOC_" ++ _ = AmocEnv <- os:getenv()]]),
+    Config;
+init_per_testcase(invalid_custom_parser_test, Config) ->
+    App = application:get_application(amoc_config_env),
+    %% setting non-existing config parser module
+    application:set_env(App, config_parser_mod, invalid_parser_module),
+    Config;
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(valid_custom_parser_test, _Config) ->
+    App = application:get_application(amoc_config_env),
+    application:unset_env(App, config_parser_mod),
+    meck:unload();
+end_per_testcase(invalid_custom_parser_test, _Config) ->
+    App = application:get_application(amoc_config_env),
+    application:unset_env(App, config_parser_mod);
+end_per_testcase(_, _Config) ->
+    ok.
+%%-----------------------------------------------------------------------------------
+%% test cases
+%%-----------------------------------------------------------------------------------
 
 parse_value_prop_test(_) ->
     RealAnyType = weighted_union([{1, map(any(), any())},
                                   {10, any()}]),
     ProperTest = ?FORALL(Value, RealAnyType,
-                         amoc_config_env:parse_value(format_value(Value)) =:= {ok, Value}),
+                         amoc_config_parser:parse_value(format_value(Value)) =:= {ok, Value}),
     ?assertEqual(true, proper:quickcheck(ProperTest, [quiet])).
 
-config_os_env_test(_) ->
-    unset_os_env(some_variable),
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)),
-    set_os_env(some_variable, some_value),
-    ?assertEqual(some_value, get_env(some_variable)),
-    ?assertEqual(some_value, get_env(some_variable, default_value)),
-    set_os_env(some_variable, another_value),
-    ?assertEqual(another_value, get_env(some_variable)),
-    ?assertEqual(another_value, get_env(some_variable, default_value)),
-    unset_os_env(some_variable),
-    ?assertEqual(undefined, get_env(some_variable)),
-    ?assertEqual(default_value, get_env(some_variable, default_value)).
+default_parser_test(_) ->
+    %% testing default config parser module (amoc_config_parser)
+    ?assertEqual(some_value, get_env(set_var)),
+    ?assertEqual(some_value, get_env(set_var, default_value)),
+    ?assertEqual(undefined, get_env(unset_var)),
+    ?assertEqual(default_value, get_env(unset_var, default_value)),
+    ?assertEqual(undefined, get_env(empty_var)),
+    ?assertEqual(default_value, get_env(empty_var, default_value)).
+
+valid_custom_parser_test(_) ->
+    %% testing invalid custom config parser module
+    Self = self(),
+
+    %% successful parsing
+    meck:expect(?MOCK_MOD, parse_value, ['_'], {ok, another_value}),
+    ?assertEqual(another_value, get_env(set_var)),
+    ?assertEqual(another_value, get_env(set_var, default_value)),
+    OkCall = {Self, {?MOCK_MOD, parse_value, ["some_value"]}, {ok, another_value}},
+    ?assertEqual([OkCall, OkCall], meck:history(?MOCK_MOD)),
+    meck:reset(?MOCK_MOD),
+
+    %% gracefully failing parsing
+    meck:expect(?MOCK_MOD, parse_value, ['_'], {error, some_error}),
+    ?assertEqual(undefined, get_env(set_var)),
+    ?assertEqual(default_value, get_env(set_var, default_value)),
+    ErrCall = {Self, {?MOCK_MOD, parse_value, ["some_value"]}, {error, some_error}},
+    ?assertEqual([ErrCall, ErrCall], meck:history(?MOCK_MOD)),
+    meck:reset(?MOCK_MOD),
+
+    %% invalid parsing return value
+    meck:expect(?MOCK_MOD, parse_value, ['_'], invalid_ret_value),
+    ?assertEqual(undefined, get_env(set_var)),
+    ?assertEqual(default_value, get_env(set_var, default_value)),
+    InvRetValCall = {Self, {?MOCK_MOD, parse_value, ["some_value"]}, invalid_ret_value},
+    ?assertEqual([InvRetValCall, InvRetValCall], meck:history(?MOCK_MOD)),
+    meck:reset(?MOCK_MOD),
+
+    %% crash during parsing
+    meck:expect(?MOCK_MOD, parse_value, fun(_) -> error(bang) end),
+    ?assertEqual(undefined, get_env(set_var)),
+    ?assertEqual(default_value, get_env(set_var, default_value)),
+    ?assertMatch([{Self, {?MOCK_MOD, parse_value, ["some_value"]}, error, bang, _},
+                  {Self, {?MOCK_MOD, parse_value, ["some_value"]}, error, bang, _}],
+                 meck:history(?MOCK_MOD)),
+    meck:reset(?MOCK_MOD),
+
+    %% unset and empty env variables (custom parsing module is not triggered)
+    ?assertEqual(undefined, get_env(unset_var)),
+    ?assertEqual(default_value, get_env(unset_var, default_value)),
+    ?assertEqual(undefined, get_env(empty_var)),
+    ?assertEqual(default_value, get_env(empty_var, default_value)),
+    ?assertEqual([], meck:history(?MOCK_MOD)).
+
+invalid_custom_parser_test(_) ->
+    %% testing invalid custom config parser module
+    ?assertEqual(undefined, get_env(set_var)),
+    ?assertEqual(default_value, get_env(set_var, default_value)),
+    ?assertEqual(undefined, get_env(unset_var)),
+    ?assertEqual(default_value, get_env(unset_var, default_value)),
+    ?assertEqual(undefined, get_env(empty_var)),
+    ?assertEqual(default_value, get_env(empty_var, default_value)).

--- a/test/amoc_config_env_SUITE.erl
+++ b/test/amoc_config_env_SUITE.erl
@@ -28,7 +28,7 @@ init_per_suite(Config) ->
     ct:pal("OS env:~n   ~p", [os:getenv()]),
     Config.
 
-end_per_suite(_)->
+end_per_suite(_) ->
     %% unset predefined variables
     unset_os_env(set_var),
     unset_os_env(empty_var).
@@ -38,7 +38,8 @@ init_per_testcase(valid_custom_parser_test, Config) ->
     App = application:get_application(amoc_config_env),
     application:set_env(App, config_parser_mod, ?MOCK_MOD),
     ct:pal("amoc_config_env module belongs to '~p' application", [App]),
-    ct:pal("AMOC_* OS env. variables:~n   ~p", [[AmocEnv || "AMOC_" ++ _ = AmocEnv <- os:getenv()]]),
+    ct:pal("AMOC_* OS env. variables:~n   ~p",
+           [[AmocEnv || "AMOC_" ++ _ = AmocEnv <- os:getenv()]]),
     Config;
 init_per_testcase(invalid_custom_parser_test, Config) ->
     App = application:get_application(amoc_config_env),

--- a/test/amoc_config_helper.erl
+++ b/test/amoc_config_helper.erl
@@ -5,6 +5,9 @@
 set_os_env(Name, Value) ->
     os:putenv(env_name(Name), format_value(Value)).
 
+set_empty_os_env(Name) ->
+    os:putenv(env_name(Name), "").
+
 unset_os_env(Name) ->
     os:unsetenv(env_name(Name)).
 
@@ -18,4 +21,4 @@ get_env(Name, Default) ->
     amoc_config_env:get(Name, Default).
 
 format_value(Value) ->
-    amoc_config_env:format(Value, string).
+    amoc_config_parser:format(Value, string).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -12,17 +12,30 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% these attributes are required for the testing purposes %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--required_variable(#{name => var0, description => "var0"}).
--required_variable(#{name => var1, description => "var1"}).
--required_variable(#{name => var2, description => "var2", default_value => def2}).
--override_variable(#{name => var2, description => "var2", default_value => val2,
-                     verification => [def2, val2], update => {?MODULE, update_fn, 2}}).
--override_variable(#{name => var3, description => "var3", default_value => def3,
-                     update => fun ?MODULE:update_fn/2}).
--override_variable(#{name => var3, description => "var3", default_value => def3,
-                     update => {?MODULE, update_fn, 2}}).
 
-update_fn(Name, Value) -> apply(?MOCK_MOD, update, [Name, Value]).
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% declaring required variables %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-required_variable(#{name => var0, description => "var0"}).
+%% without overriding, verification  of var1 should fail.
+-required_variable(#{name => var1, description => "var1",
+                     verification => [unused_value]}).
+-required_variable(#{name => var2, description => "var2", default_value => def2}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% overriding variables %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+-override_variable([#{name => var1, description => "var1", default_value => val1,
+                     verification => fun ?MOCK_MOD:verify_fun/1},
+                    #{name => var2, description => "var2", default_value => val2,
+                      verification => [new_val2, val2],
+                      update => {?MOCK_MOD, update_mfa, 2}}]).
+%% var3 is not declared with -required_variable(...), but it's fine.
+-override_variable(#{name => var3, description => "var3", default_value => def3}).
+-override_variable(#{name => var3, description => "var3", default_value => val3,
+                     update => fun ?MOCK_MOD:update_fun/2,
+                     verification => {?MOCK_MOD, verify_mfa, 1}}).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
@@ -41,13 +54,32 @@ groups() ->
                             update_settings_invalid_value,
                             update_settings_undef_param]}].
 
-init_per_group(update_settings, Config) ->
+init_per_suite(Config) ->
     meck:new(?MOCK_MOD, [non_strict, no_link]),
-    meck:expect(?MOCK_MOD, update, ['_', '_'], ok),
+    meck:expect(?MOCK_MOD, update_mfa, ['_', '_'], ok),
+    meck:expect(?MOCK_MOD, verify_mfa, ['_'], true),
+    meck:expect(?MOCK_MOD, update_fun, ['_', '_'], ok),
+    meck:expect(?MOCK_MOD, verify_fun, ['_'], true),
     Config.
 
-end_per_group(update_settings, Config) ->
-    meck:unload(),
+end_per_suite(Config) ->
+    meck:unload(?MOCK_MOD),
+    Config.
+
+init_per_testcase(TC, Config) when TC =:= crash_during_scenario_settings_parsing;
+                                   TC =:= invalid_module_attributes ->
+    meck:new(amoc_config_attributes, [no_link]),
+    Config;
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(TC, Config) when TC =:= crash_during_scenario_settings_parsing;
+                                  TC =:= invalid_module_attributes ->
+    meck:unload(amoc_config_attributes),
+    meck:reset(?MOCK_MOD),
+    Config;
+end_per_testcase(_, Config) ->
+    meck:reset(?MOCK_MOD),
     Config.
 
 parse_scenario_settings(_) ->
@@ -57,6 +89,11 @@ parse_scenario_settings(_) ->
                         {var1, def1}],
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
     ?assertEqual(ok, Ret),
+    %% check verification function calls
+    meck:wait(?MOCK_MOD, verify_fun, [def1], 0),
+    meck:wait(?MOCK_MOD, verify_mfa, [val3], 0),
+    ?assertEqual(2, length(meck:history(?MOCK_MOD))),
+    assert_no_update_calls(),
     %% undefined variable
     ?assertThrow({invalid_setting, undefined_var}, amoc_config:get(undefined_var)),
     %% undefined value
@@ -71,30 +108,44 @@ parse_scenario_settings(_) ->
     ?assertEqual(500, amoc_config:get(interarrival)).
 
 update_settings(_) ->
-    mock_ets_tables(),
-    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    set_initial_configuration(),
+
+    %% update 2 parameters and check all values and
+    %% verification/update function calls
+    ScenarioSettings = [{var3, new_val3},
+                        {var2, new_val2}],
+    Ret = amoc_config_scenario:update_settings(ScenarioSettings),
     ?assertEqual(ok, Ret),
-    ScenarioSettings = [{var3, val3},
-                        {var2, def2}],
-    Ret2 = amoc_config_scenario:update_settings(ScenarioSettings),
-    ?assertEqual(ok, Ret2),
     %% updated variables
-    ?assertEqual(def2, amoc_config:get(var2)),
-    ?assertEqual(val3, amoc_config:get(var3)),
+    ?assertEqual(new_val2, amoc_config:get(var2)),
+    ?assertEqual(new_val3, amoc_config:get(var3)),
     %% unchanged variables
     ?assertEqual(undefined, amoc_config:get(var0)),
-    ?assertEqual(undefined, amoc_config:get(var1)),
-    [meck:wait(?MOCK_MOD, update, [Name, Value], 500)
-     || {Name, Value} <- ScenarioSettings],
-    meck:reset(?MOCK_MOD).
+    ?assertEqual(val1, amoc_config:get(var1)),
+    %% execution of update functions is done asynchronously
+    %% and execution of verification functions is synchronous
+    meck:wait(?MOCK_MOD, verify_mfa, [new_val3], 0),
+    meck:wait(?MOCK_MOD, update_fun, [var3, new_val3], 500),
+    meck:wait(?MOCK_MOD, update_mfa, [var2, new_val2], 500),
+    ?assertEqual(3, length(meck:history(?MOCK_MOD))),
+    meck:reset(?MOCK_MOD),
+
+    %% update only 1 parameter and check that update
+    %% function is call for that parameter
+    ?assertEqual(ok, amoc_config_scenario:update_settings([{var2, val2}])),
+    %% updated variables
+    ?assertEqual(val2, amoc_config:get(var2)),
+    %% execution of update functions is done asynchronously
+    %% and execution of verification functions is synchronous
+    meck:wait(?MOCK_MOD, update_mfa, [var2, val2], 500),
+    ?assertEqual(1, length(meck:history(?MOCK_MOD))).
 
 update_settings_readonly(_) ->
-    mock_ets_tables(),
-    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    set_initial_configuration(),
     Table = ets:tab2list(amoc_config),
     %% updating readonly parameters
     ScenarioSettings = [{var0, val0},
-                        {var1, def1},
+                        {var1, val1}, %% the same value as set initially
                         {var3, val3}],
     ReadOnlyRet = amoc_config_scenario:update_settings(ScenarioSettings),
     ?assertEqual({error, readonly_parameters,
@@ -102,48 +153,55 @@ update_settings_readonly(_) ->
                    {var1, ?MODULE}]},
                  ReadOnlyRet),
     is_equal_list(Table, ets:tab2list(amoc_config)),
-    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+    assert_no_update_calls(),
+    assert_no_verify_calls().
 
 update_settings_invalid_value(_) ->
-    mock_ets_tables(),
-    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    set_initial_configuration(),
     Table = ets:tab2list(amoc_config),
     %% invalid value
-    ScenarioSettings2 = [{var3, val3},
+    ScenarioSettings2 = [{var3, new_val3},
                          {var2, invalid_val2}],
     InvalidValueRet = amoc_config_scenario:update_settings(ScenarioSettings2),
     ?assertEqual({error, parameters_verification_failed,
                   [{var2, invalid_val2,
-                    {verification_failed, {not_one_of, [def2, val2]}}}]},
+                    {verification_failed, {not_one_of, [new_val2, val2]}}}]},
                  InvalidValueRet),
     is_equal_list(Table, ets:tab2list(amoc_config)),
-    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+    assert_no_update_calls().
 
 update_settings_undef_param(_) ->
-    mock_ets_tables(),
-    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    set_initial_configuration(),
     Table = ets:tab2list(amoc_config),
-    %% undefined parameter
-    ScenarioSettings3 = [{var3, val3},
+    %% reset initial verification calls.
+    meck:reset(?MOCK_MOD),
+    %% adding undefined parameter in settings
+    ScenarioSettings3 = [{var3, new_val3},
                          {invalid_var2, val2}],
     UndefParamRet = amoc_config_scenario:update_settings(ScenarioSettings3),
     ?assertEqual({error, undefined_parameters, [invalid_var2]}, UndefParamRet),
     is_equal_list(Table, ets:tab2list(amoc_config)),
-    ?assertError(timeout, meck:wait(?MOCK_MOD, update, 2, 500)).
+    assert_no_update_calls(),
+    assert_no_verify_calls().
+
 
 implicit_variable_redefinition(_) ->
     mock_ets_tables(),
     ets:insert(amoc_scenarios, {?MODULE, configurable}),
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
-    ?assertEqual({error, parameter_overriding, {var0, ?MODULE, ?MODULE}}, Ret).
+    ?assertEqual({error, parameter_overriding, {var0, ?MODULE, ?MODULE}}, Ret),
+    assert_no_update_calls(),
+    assert_no_verify_calls().
 
 invalid_settings(_) ->
     mock_ets_tables(),
     ScenarioSettings = [{invalid_var1, invalid_value},
-                        {var2, def2},
+                        {var2, new_val2},
                         {invalid_var2, invalid_value}],
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
-    ?assertEqual({error, undefined_parameters, [invalid_var2, invalid_var1]}, Ret).
+    ?assertEqual({error, undefined_parameters, [invalid_var2, invalid_var1]}, Ret),
+    assert_no_update_calls(),
+    assert_no_verify_calls().
 
 invalid_value(_) ->
     mock_ets_tables(),
@@ -151,35 +209,61 @@ invalid_value(_) ->
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, ScenarioSettings),
     ?assertEqual({error, parameters_verification_failed,
                   [{var2, invalid_value,
-                    {verification_failed, {not_one_of, [def2, val2]}}}]},
-                 Ret).
-
+                    {verification_failed, {not_one_of, [new_val2, val2]}}}]},
+                 Ret),
+    %% check verification function calls, verification
+    meck:wait(?MOCK_MOD, verify_fun, [val1], 0),
+    meck:wait(?MOCK_MOD, verify_mfa, [val3], 0),
+    assert_no_update_calls(),
+    ?assertEqual(2, length(meck:history(?MOCK_MOD))).
 
 crash_during_scenario_settings_parsing(_) ->
     mock_ets_tables(),
-    meck:new(amoc_config_attributes, []),
     ExceptionValue = some_exception,
     meck:expect(amoc_config_attributes, get_module_configuration,
                 fun(_, _) -> meck:exception(throw, ExceptionValue) end),
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
-    ?assertMatch({error, pipeline_action_crashed, {throw, some_exception, _}},
-                 Ret),
-    meck:unload().
+    ?assertMatch({error, pipeline_action_crashed, {throw, some_exception, _}}, Ret),
+    assert_no_update_calls(),
+    assert_no_verify_calls().
 
 invalid_module_attributes(_) ->
     mock_ets_tables(),
-    meck:new(amoc_config_attributes, []),
     ErrorValue = {error, some_error_type, some_error_reason},
     meck:expect(amoc_config_attributes, get_module_configuration,
                 fun(_, _) -> ErrorValue end),
     Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
     ?assertEqual(ErrorValue, Ret),
-    meck:unload().
+    assert_no_update_calls(),
+    assert_no_verify_calls().
 
 mock_ets_tables() ->
     EtsOptions = [named_table, protected, {read_concurrency, true}],
     amoc_scenarios = ets:new(amoc_scenarios, EtsOptions),
     amoc_config_utils:create_amoc_config_ets().
 
+assert_no_update_calls() ->
+    %% execution of update functions is done asynchronously
+    ?assertError(timeout, meck:wait(?MOCK_MOD, update_mfa, 2, 500)),
+    ?assertError(timeout, meck:wait(?MOCK_MOD, update_fun, 2, 0)).
+
+assert_no_verify_calls() ->
+    %% execution of verification functions is done synchronously
+    ?assertError(timeout, meck:wait(?MOCK_MOD, verify_mfa, 1, 0)),
+    ?assertError(timeout, meck:wait(?MOCK_MOD, verify_fun, 1, 0)).
+
 is_equal_list(List1, List2) ->
     ?assertEqual(lists:sort(List1), lists:sort(List2)).
+
+set_initial_configuration() ->
+    mock_ets_tables(),
+    Ret = amoc_config_scenario:parse_scenario_settings(?MODULE, []),
+    ?assertEqual(ok, Ret),
+    %% check verification function calls
+    % ct:pal("meck:history(?MOCK_MOD) = ~p", [meck:history(?MOCK_MOD)]),
+    meck:wait(?MOCK_MOD, verify_fun, [val1], 0),
+    meck:wait(?MOCK_MOD, verify_mfa, [val3], 0),
+    %% reset initial verification calls.
+    assert_no_update_calls(),
+    ?assertEqual(2, length(meck:history(?MOCK_MOD))),
+    meck:reset(?MOCK_MOD).

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -51,15 +51,15 @@ all() ->
      invalid_module_attributes,
      invalid_settings,
      invalid_value,
-     {group, update_settings}].
+     update_settings,
+     update_just_one_parameter,
+     update_parameters_with_the_same_values,
+     update_settings_readonly,
+     update_settings_invalid_value,
+     update_settings_undef_param].
 
 groups() ->
-    [{update_settings, [], [update_settings,
-                            update_just_one_parameter,
-                            update_parameters_with_the_same_values,
-                            update_settings_readonly,
-                            update_settings_invalid_value,
-                            update_settings_undef_param]}].
+    [{update_settings, [], []}].
 
 init_per_suite(Config) ->
     meck:new(?MOCK_MOD, [non_strict, no_link]),

--- a/test/amoc_config_verification_SUITE.erl
+++ b/test/amoc_config_verification_SUITE.erl
@@ -42,10 +42,10 @@ process_scenario_config_shadows_default_values(_) ->
     ?assertEqual({ok, ScenarioConfig}, Result4).
 
 process_scenario_config_returns_error_for_invalid_values(_) ->
-    VerificationFN = fun(_) -> {false, some_reason} end,
+    VerificationFn = fun(_) -> {false, some_reason} end,
     IncorrectScenarioConfig =
     [#module_parameter{name = wrong_param, mod = ?MOD, value = any_value,
-                       verification_fn = VerificationFN}
+                       verification_fn = VerificationFn}
      | incorrect_scenario_config()],
     given_scenario_parameters_not_set(IncorrectScenarioConfig),
     Result = amoc_config_verification:process_scenario_config(IncorrectScenarioConfig, []),


### PR DESCRIPTION
This PR introduces the following changes:
• Possibility to customise parsing (de-serialisation) logic for env variables.
• small improvements for `amoc_config_scenario:update_settings/1` logic.
• extension of the tests.