### PR TITLE
Telemetry curation

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -6,15 +6,15 @@ A telemetry span of a full scenario execution globally (i.e. the exported `init/
 ```erlang
 event_name: [amoc, scenario, run, _]
 measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario => module()} %% Plus as described in `telemetry:span/3`
+metadata: #{scenario := module()} %% Plus as described in `telemetry:span/3`
 ```
 
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
 event_name: [amoc, scenario, user, _]
 measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario => module(),
-            user_id => non_neg_integer()} %% Plus as described in `telemetry:span/3`
+metadata: #{scenario := module(),
+            user_id := non_neg_integer()} %% Plus as described in `telemetry:span/3`
 ```
 
 ## Controller
@@ -22,8 +22,8 @@ metadata: #{scenario => module(),
 Indicates the number of users manually added or removed
 ```erlang
 event_name: [amoc, controller, users]
-measurements: #{count => non_neg_integer()}
-metadata: #{monotonic_time => integer(), scenario => module(), type => add | remove}
+measurements: #{count := non_neg_integer()}
+metadata: #{monotonic_time := integer(), scenario := module(), type := add | remove}
 ```
 
 ## Throttle
@@ -33,8 +33,8 @@ metadata: #{monotonic_time => integer(), scenario => module(), type => add | rem
 Raised when a throttle mechanism is initialised.
 ```erlang
 event_name: [amoc, throttle, init]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ### Rate
@@ -43,8 +43,8 @@ Raised when a throttle mechanism is initialised or its configured rate is change
 This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, rate]
-measurements: #{rate => non_neg_integer()}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{rate := non_neg_integer()}
+metadata: #{monotonic_time := integer(), name := atom(), msg => binary()}
 ```
 
 ### Request
@@ -53,8 +53,8 @@ Raised when a process client requests to be allowed pass through a throttled mec
 This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, request]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ### Execute
@@ -63,8 +63,8 @@ Raised when a process client is allowed to execute after a throttled mechanism.
 This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, execute]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ## Coordinator
@@ -74,6 +74,6 @@ Indicates when a coordinating event was raised, like a process being added for c
 ### Event
 ```erlang
 event_name: [amoc, coordinator, start | stop | add | reset | timeout]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,12 +2,19 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
+A telemetry span of a full scenario execution globally (i.e. the exported `init/0` function):
+```erlang
+event_name: [amoc, scenario, run, _]
+measurements: #{} %% As described in `telemetry:span/3`
+metadata: #{scenario => module()} %% Plus as described in `telemetry:span/3`
+```
+
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
 event_name: [amoc, scenario, user, _]
 measurements: #{} %% As described in `telemetry:span/3`
 metadata: #{scenario => module(),
-            user_id => non_neg_integer()}
+            user_id => non_neg_integer()} %% Plus as described in `telemetry:span/3`
 ```
 
 ## Controller

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,11 +2,12 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
-A telemetry span of a full scenario execution
+A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
-event_name: [amoc, scenario, user]
-measurements: #{}
-metadata: #{}
+event_name: [amoc, scenario, user, _]
+measurements: #{} %% As described in `telemetry:span/3`
+metadata: #{scenario => module(),
+            user_id => non_neg_integer()}
 ```
 
 ## Controller

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -31,42 +31,40 @@ metadata: #{monotonic_time => integer(), scenario => module(), type => add | rem
 ### Init
 
 Raised when a throttle mechanism is initialised.
-
 ```erlang
 event_name: [amoc, throttle, init]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Rate
 
 Raised when a throttle mechanism is initialised or its configured rate is changed.
 This event is raised only on the master node.
-
 ```erlang
 event_name: [amoc, throttle, rate]
 measurements: #{rate => non_neg_integer()}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Request
 
 Raised when a process client requests to be allowed pass through a throttled mechanism.
-
+This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, request]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Execute
 
 Raised when a process client is allowed to execute after a throttled mechanism.
-
+This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, execute]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ## Coordinator

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -97,3 +97,13 @@ event_name: [amoc, config, get | verify | env]
 measurements: #{}
 metadata: #{log_class => syslog_level(), _ => _}
 ```
+
+## Cluster
+
+### Internal events
+There are related to clustering events
+```erlang
+event_name: [amoc, cluster, connect_nodes | nodedown | master_node_down]
+measurements: #{count => non_neg_integer()},
+metadata: #{node => node(), nodes => nodes(), state => map()}
+```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -19,11 +19,11 @@ metadata: #{scenario => module(),
 
 ## Controller
 
-Indicates the number of users added or removed
+Indicates the number of users manually added or removed
 ```erlang
 event_name: [amoc, controller, users]
 measurements: #{count => non_neg_integer()}
-metadata: #{type => add | remove}
+metadata: #{monotonic_time => integer(), scenario => module(), type => add | remove}
 ```
 
 ## Throttle

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -87,3 +87,13 @@ event_name: [amoc, coordinator, start | stop | add | reset | timeout]
 measurements: #{count := 1}
 metadata: #{monotonic_time := integer(), name := atom()}
 ```
+
+## Config
+
+### Internal events
+There are related to bad configuration events, they might deserve logging
+```erlang
+event_name: [amoc, config, get | verify | env]
+measurements: #{}
+metadata: #{log_class => syslog_level(), _ => _}
+```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -75,5 +75,5 @@ Indicates when a coordinating event was raised, like a process being added for c
 ```erlang
 event_name: [amoc, coordinator, start | stop | add | reset | timeout]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -67,6 +67,16 @@ measurements: #{count := 1}
 metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
+### Throttle process internals
+
+Events related to internals of the throttle processes, these might expose unstable conditions you
+might want to log or reconfigure:
+```erlang
+event_name: [amoc, throttle, process]
+measurements: #{msg := binary(), process := pid()}
+metadata: #{monotonic_time := integer(), name := atom(), printable_state => map()}
+```
+
 ## Coordinator
 
 Indicates when a coordinating event was raised, like a process being added for coordination or a timeout being triggered

--- a/src/amoc_config/amoc_config.erl
+++ b/src/amoc_config/amoc_config.erl
@@ -4,7 +4,6 @@
 %%==============================================================================
 -module(amoc_config).
 
--include_lib("kernel/include/logger.hrl").
 -include("amoc_config.hrl").
 
 -export([get/1, get/2]).
@@ -21,13 +20,17 @@ get(Name) ->
 get(Name, Default) when is_atom(Name) ->
     case ets:lookup(amoc_config, Name) of
         [] ->
-            ?LOG_ERROR("no scenario setting ~p", [Name]),
+            telemetry:execute([amoc, config, get], #{},
+                              #{log_class => error, msg => <<"no scenario setting">>,
+                                scenario => Name}),
             throw({invalid_setting, Name});
         [#module_parameter{name = Name, value = undefined}] ->
             Default;
         [#module_parameter{name = Name, value = Value}] ->
             Value;
         InvalidLookupRet ->
-            ?LOG_ERROR("invalid lookup return value ~p ~p", [Name, InvalidLookupRet]),
+            telemetry:execute([amoc, config, get], #{},
+                              #{log_class => error, msg => <<"invalid lookup return value">>,
+                                scenario => Name, return => InvalidLookupRet}),
             throw({invalid_lookup_ret_value, InvalidLookupRet})
     end.

--- a/src/amoc_config/amoc_config_verification.erl
+++ b/src/amoc_config/amoc_config_verification.erl
@@ -9,9 +9,7 @@
 %% API
 -export([process_scenario_config/2]).
 
--include_lib("kernel/include/logger.hrl").
 -include("amoc_config.hrl").
-
 
 -spec process_scenario_config(module_configuration(), settings()) ->
     {ok, module_configuration()} | error().
@@ -41,12 +39,17 @@ verify(Fun, Value) ->
         {true, NewValue} -> {true, NewValue};
         {false, Reason} -> {false, {verification_failed, Reason}};
         Ret ->
-            ?LOG_ERROR("invalid verification method ~p(~p), return value : ~p",
-                       [Fun, Value, Ret]),
+            telemetry:execute([amoc, config, verify], #{error => 1},
+                              #{log_class => error, verification_method => Fun,
+                                verification_arg => Value, verification_return => Ret,
+                                msg => <<"invalid verification method">>}),
             {false, {invalid_verification_return_value, Ret}}
     catch
         C:E:S ->
-            ?LOG_ERROR("invalid verification method ~p(~p), exception: ~p ~p ~p",
-                       [Fun, Value, C, E, S]),
+            telemetry:execute([amoc, config, verify], #{error => 1},
+                              #{log_class => error, verification_method => Fun,
+                                verification_arg => Value,
+                                kind => C, reason => E, stacktrace => S,
+                                msg => <<"invalid verification method">>}),
             {false, {exception_during_verification, {C, E, S}}}
     end.

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -98,13 +98,11 @@ update_settings(Settings) ->
 -spec add_users(amoc_scenario:user_id(), amoc_scenario:user_id()) ->
     ok | {error, term()}.
 add_users(StartId, EndId) ->
-    telemetry:execute([amoc, controller, users], #{count => EndId - StartId + 1}, #{type => add}),
     %% adding the exact range of the users
     gen_server:call(?SERVER, {add, StartId, EndId}).
 
 -spec remove_users(user_count(), boolean()) -> {ok, user_count()}.
 remove_users(Count, ForceRemove) ->
-    telemetry:execute([amoc, controller, users], #{count => Count}, #{type => remove}),
     %% trying to remove Count users, this action is async!!!
     gen_server:call(?SERVER, {remove, Count, ForceRemove}).
 
@@ -229,8 +227,12 @@ handle_update_settings(_Settings, #state{status = Status}) ->
 handle_add(StartId, EndId, #state{last_user_id = LastId,
                                   create_users = ScheduledUsers,
                                   status       = running,
+                                  scenario     = Scenario,
                                   tref         = TRef} = State) when StartId =< EndId,
                                                                      LastId < StartId ->
+    TimeStamp = erlang:monotonic_time(),
+    telemetry:execute([amoc, controller, users], #{count => EndId - StartId + 1},
+                      #{monotonic_time => TimeStamp, scenario => Scenario, type => add}),
     NewUsers = lists:seq(StartId, EndId),
     NewScheduledUsers = lists:append(ScheduledUsers, NewUsers),
     NewTRef = maybe_start_timer(TRef),
@@ -242,7 +244,10 @@ handle_add(_StartId, _EndId, #state{status = Status} = State) ->
     {{error, {invalid_status, Status}}, State}.
 
 -spec handle_remove(user_count(), boolean(), state()) -> handle_call_res().
-handle_remove(Count, ForceRemove, #state{status = running}) ->
+handle_remove(Count, ForceRemove, #state{status = running, scenario = Scenario}) ->
+    TimeStamp = erlang:monotonic_time(),
+    telemetry:execute([amoc, controller, users], #{count => Count},
+                      #{monotonic_time => TimeStamp, scenario => Scenario, type => remove}),
     Pids = case ets:match_object(?USERS_TABLE, '$1', Count) of
                {Objects, _} -> [Pid || {_Id, Pid} <- Objects];
                '$end_of_table' -> []

--- a/src/amoc_coordinator/amoc_coordinator.erl
+++ b/src/amoc_coordinator/amoc_coordinator.erl
@@ -74,7 +74,8 @@ start(Name, CoordinationPlan, Timeout) when ?IS_TIMEOUT(Timeout) ->
     Plan = normalize_coordination_plan(CoordinationPlan),
     case gen_event:start({local, Name}) of
         {ok, _} ->
-            telemetry:execute([amoc, coordinator, start], #{count => 1}, #{name => Name}),
+            telemetry:execute([amoc, coordinator, start], #{count => 1},
+                              #{monotonic_time => erlang:monotonic_time(), name => Name}),
             %% according to gen_event documentation:
             %%
             %%    When the event is received, the event manager calls
@@ -99,7 +100,8 @@ start(Name, CoordinationPlan, Timeout) when ?IS_TIMEOUT(Timeout) ->
 -spec stop(name()) -> ok.
 stop(Name) ->
     gen_event:stop(Name),
-    telemetry:execute([amoc, coordinator, stop], #{count => 1}, #{name => Name}).
+    telemetry:execute([amoc, coordinator, stop], #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
 
 %% @see add/3
 -spec add(name(), any()) -> ok.
@@ -163,8 +165,8 @@ handle_event(Event, {timeout, Name, Pid}) ->
                          reset_coordinator -> reset;
                          coordinator_timeout -> timeout
                      end,
-    telemetry:execute([amoc, coordinator, TelemetryEvent],
-                       #{count => 1}, #{name => Name}),
+    telemetry:execute([amoc, coordinator, TelemetryEvent], #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}),
     erlang:send(Pid, Event),
     {ok, {timeout, Name, Pid}};
 handle_event(Event, {worker, WorkerPid}) ->

--- a/src/amoc_scenario.erl
+++ b/src/amoc_scenario.erl
@@ -35,7 +35,7 @@
 init(Scenario) ->
     apply_safely(Scenario, init, []).
 
--spec terminate(amoc:scenario(), state()) -> {ok, any()} | {error, Reason :: term()}.
+-spec terminate(amoc:scenario(), state()) -> ok | {ok, any()} | {error, Reason :: term()}.
 terminate(Scenario, State) ->
     case {erlang:function_exported(Scenario, terminate, 1),
           erlang:function_exported(Scenario, terminate, 0)} of

--- a/src/amoc_throttle/amoc_throttle_controller.erl
+++ b/src/amoc_throttle/amoc_throttle_controller.erl
@@ -202,7 +202,14 @@ maybe_raise_event(Name, Event) ->
     end.
 
 raise_event(Name, Event) when Event =:= request; Event =:= execute; Event =:= init ->
-    telemetry:execute([amoc, throttle, Event], #{count => 1}, #{name => Name}).
+    telemetry:execute([amoc, throttle, Event],
+                      #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
+
+report_rate(Name, RatePerMinute) ->
+    telemetry:execute([amoc, throttle, rate],
+                      #{rate => RatePerMinute},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
 
 -spec change_rate_and_stop_plan(name(), state()) -> state().
 change_rate_and_stop_plan(Name, State) ->
@@ -325,6 +332,3 @@ run_cmd(Pid, pause) ->
     amoc_throttle_process:pause(Pid);
 run_cmd(Pid, resume) ->
     amoc_throttle_process:resume(Pid).
-
-report_rate(Name, RatePerMinute) ->
-    telemetry:execute([amoc, throttle, rate], #{rate => RatePerMinute}, #{name => Name}).

--- a/src/amoc_throttle/amoc_throttle_process.erl
+++ b/src/amoc_throttle/amoc_throttle_process.erl
@@ -21,8 +21,6 @@
          handle_continue/2,
          format_status/2]).
 
--include_lib("kernel/include/logger.hrl").
-
 -define(DEFAULT_MSG_TIMEOUT, 60000).%% one minute
 
 -record(state, {can_run_fn = true :: boolean(),
@@ -75,7 +73,7 @@ get_state(Pid) ->
 %%------------------------------------------------------------------------------
 -spec init(list()) -> {ok, state(), timeout()}.
 init([Name, Interval, Rate]) ->
-    InitialState = initial_state(Interval, Rate),
+    InitialState = initial_state(Name, Interval, Rate),
     StateWithTimer = maybe_start_timer(InitialState),
     {ok, StateWithTimer#state{name = Name}, timeout(InitialState)}.
 
@@ -85,7 +83,7 @@ handle_info({'DOWN', _, process, _, _}, State) ->
 handle_info(delay_between_executions, State) ->
     {noreply, State#state{can_run_fn = true}, {continue, maybe_run_fn}};
 handle_info(timeout, State) ->
-    log_state("is inactive", State),
+    internal_event(<<"is inactive">>, State),
     {noreply, State, {continue, maybe_run_fn}}.
 
 -spec handle_cast(term(), state()) ->
@@ -99,9 +97,9 @@ handle_cast(resume_process, State) ->
 handle_cast({schedule, RunnerPid}, #state{schedule_reversed = SchRev, name = Name} = State) ->
     amoc_throttle_controller:telemetry_event(Name, request),
     {noreply, State#state{schedule_reversed = [RunnerPid | SchRev]}, {continue, maybe_run_fn}};
-handle_cast({update, Interval, Rate}, State) ->
-    NewState = merge_state(initial_state(Interval, Rate), State),
-    log_state("state update", NewState),
+handle_cast({update, Interval, Rate}, #state{name = Name} = State) ->
+    NewState = merge_state(initial_state(Name, Interval, Rate), State),
+    internal_event(<<"state update">>, NewState),
     {noreply, NewState, {continue, maybe_run_fn}}.
 
 -spec handle_call(term(), term(), state()) ->
@@ -126,23 +124,26 @@ format_status(_Opt, [_PDict, State]) ->
 %%------------------------------------------------------------------------------
 %% internal functions
 %%------------------------------------------------------------------------------
-initial_state(Interval, 0) ->
-    ?LOG_ERROR("invalid rate, must be higher than zero"),
-    initial_state(Interval, 1);
-initial_state(Interval, Rate) when Rate > 0 ->
-    case Rate < 5 of
-        true -> ?LOG_ERROR("too low rate, please reduce NoOfProcesses");
-        false -> ok
-    end,
-    Delay = case {Interval, Interval div Rate, Interval rem Rate} of
+initial_state(Name, Interval, Rate) when Rate >= 0 ->
+    NewRate = case {Rate =:= 0, Rate < 5} of
+                  {true, _} ->
+                      internal_event(<<"invalid rate, must be higher than zero">>, Name),
+                      1;
+                  {_, true} ->
+                      internal_event(<<"too low rate, please reduce NoOfProcesses">>, Name),
+                      Rate;
+                  {_, false} ->
+                      Rate
+              end,
+    Delay = case {Interval, Interval div NewRate, Interval rem NewRate} of
                 {0, _, _} -> 0; %% limit only No of simultaneous executions
                 {_, I, _} when I < 10 ->
-                    ?LOG_ERROR("too high rate, please increase NoOfProcesses"),
+                    internal_event(<<"too high rate, please increase NoOfProcesses">>, Name),
                     10;
                 {_, DelayBetweenExecutions, 0} -> DelayBetweenExecutions;
                 {_, DelayBetweenExecutions, _} -> DelayBetweenExecutions + 1
             end,
-    #state{interval = Interval, n = Rate, max_n = Rate, delay_between_executions = Delay}.
+    #state{interval = Interval, n = NewRate, max_n = NewRate, delay_between_executions = Delay}.
 
 merge_state(#state{interval = I, delay_between_executions = D, n = N, max_n = MaxN},
             #state{n = OldN, max_n = OldMaxN} = OldState) ->
@@ -203,21 +204,27 @@ inc_n(#state{n = N, max_n = MaxN} = State) ->
     NewN = N + 1,
     case MaxN < NewN of
         true ->
-            PrintableState = printable_state(State),
-            ?LOG_ERROR("~nthrottle process ~p: invalid N (~p)~n", [self(), PrintableState]),
+            internal_event(<<"throttle proccess has invalid N">>, State),
             State#state{n = MaxN};
         false ->
             State#state{n = NewN}
     end.
 
-log_state(Msg, State) ->
+internal_event(Msg, #state{name = Name} = State) ->
     PrintableState = printable_state(State),
-    ?LOG_DEBUG("~nthrottle process ~p: ~s (~p)~n", [self(), Msg, PrintableState]).
+    telemetry:execute([amoc, throttle, process],
+                      #{msg => Msg, process => self()},
+                      #{printable_state => PrintableState,
+                        monotonic_time => erlang:monotonic_time(), name => Name});
+internal_event(Msg, Name) when is_atom(Name) ->
+    telemetry:execute([amoc, throttle, process],
+                      #{msg => Msg, process => self()},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
 
 printable_state(#state{} = State) ->
     Fields = record_info(fields, state),
     [_ | Values] = tuple_to_list(State#state{schedule = [], schedule_reversed = []}),
     StateMap = maps:from_list(lists:zip(Fields, Values)),
     StateMap#{
-        schedule:=length(State#state.schedule),
-        schedule_reversed:=length(State#state.schedule_reversed)}.
+        schedule := length(State#state.schedule),
+        schedule_reversed := length(State#state.schedule_reversed)}.

--- a/src/amoc_user.erl
+++ b/src/amoc_user.erl
@@ -30,4 +30,4 @@ init(Parent, Scenario, Id, State) ->
     proc_lib:init_ack(Parent, {ok, self()}),
     process_flag(trap_exit, true),
     ScenarioFun = fun() -> {amoc_scenario:start(Scenario, Id, State), #{}} end,
-    telemetry:span([amoc, scenario, user], #{}, ScenarioFun).
+    telemetry:span([amoc, scenario, user], #{scenario => Scenario, user_id => Id}, ScenarioFun).

--- a/test/amoc_coordinator_SUITE.erl
+++ b/test/amoc_coordinator_SUITE.erl
@@ -327,9 +327,8 @@ assert_telemetry_events(Name, [{_Pid, Call, _Ret} | History], [Event | EventList
 assert_telemetry_handler_call(Name, Call, Event) ->
     EventName = [amoc, coordinator, Event],
     Measurements = #{count => 1},
-    EventMetadata = #{name => Name},
     HandlerConfig = ?TELEMETRY_HANDLER_CONFIG,
-    ExpectedHandlerCall = {?TELEMETRY_HANDLER, handler,
-                           [EventName, Measurements,
-                            EventMetadata, HandlerConfig]},
-    ?assertEqual(ExpectedHandlerCall, Call).
+    ?assertMatch(
+       {?TELEMETRY_HANDLER, handler,
+        [EventName, Measurements,
+         #{name := Name, monotonic_time := _}, HandlerConfig]}, Call).


### PR DESCRIPTION
I'm going to want timestamps for all these telemetry events, so that metrics collectors can aggregate and draw plots based on time.

I also want an event for scenario start and stop which will mimic telemetry's `span` mechanism, but which here it is done in this way because the controller separately calls the beginning and the end of the scenario and `span` wouldn't fit into this mechanism.

I also don't want logs to be raised by `amoc`. Logging might be desired to work differently, so instead of logs I'll also raise here telemetry events for internals, and in the subscribers I'll decide if I want to log something or not and how.