### PR TITLE
This happens when running the Elixir code_server

### DIFF
--- a/src/amoc_code_server.erl
+++ b/src/amoc_code_server.erl
@@ -204,6 +204,8 @@ maybe_add_module(Module) ->
             {error, module_is_not_loaded};
         {{file, _BeamFile}, error} ->
             {error, no_beam_file_for_module};
+        {{file, ""}, {Module, Binary, Filename}} ->
+            maybe_store_uploaded_module(Module, Binary, Filename);
         {{file, BeamFile}, {Module, _Binary, Filename}} when BeamFile =/= Filename ->
             {error, code_path_collision};
         {{file, BeamFile}, {Module, Binary, BeamFile}} ->


### PR DESCRIPTION
We want to accept this module. It's too complicated to reason why between Erlang's and Elixir's code servers these would result in different paths and hence we simply want to let this pass as it is a sufficiently uncommon edge-case.