### PR TITLE
Permit scenario start when the previous is finished too

### DIFF
--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -181,7 +181,8 @@ handle_info(_Msg, State) ->
 %% ------------------------------------------------------------------
 -spec handle_start_scenario(module(), amoc_config:settings(), state()) ->
     {handle_call_res(), state()}.
-handle_start_scenario(Scenario, Settings, #state{status = idle} = State) ->
+handle_start_scenario(Scenario, Settings, #state{status = Status} = State)
+  when Status =:= idle; Status =:= finished ->
     case init_scenario(Scenario, Settings) of
         {ok, ScenarioState} ->
             NewState = State#state{scenario       = Scenario,


### PR DESCRIPTION
This happens when I run a scenario, this one finishes, and the status of the controller is left as `finished`, and then I want to run a new scenario but the controller complains that the status is invalid, when really I could perfectly start a new one.

Note that the controller has no tests on its own and therefore none are added here, actual tests want to be added later in a special PR.