### PR TITLE
Handle stop request with already zero users

### DIFF
--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -196,6 +196,10 @@ handle_start_scenario(_Scenario, _Settings, #state{status = Status} = State) ->
     {{error, {invalid_status, Status}}, State}.
 
 -spec handle_stop_scenario(state()) -> {handle_call_res(), state()}.
+handle_stop_scenario(#state{scenario = Scenario, scenario_state = ScenarioState,
+                            no_of_users = 0, status = running} = State) ->
+    amoc_scenario:terminate(Scenario, ScenarioState),
+    {ok, State#state{status = finished}};
 handle_stop_scenario(#state{status = running} = State) ->
     terminate_all_users(),
     {ok, State#state{status = terminating}};


### PR DESCRIPTION
Handle case where users already reached zero and there are no users to terminate on stop request. This can happen when the users die very fast for example, and therefore the count never really grows above zero. It can also happen if the test was left running for long enough for all the users to have finished their jobs.

Note that the controller has no tests on its own and therefore none are added here, actual tests want to be added later in a special PR.