### PR TITLE
Telemetry/timestamps and spans

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -6,15 +6,15 @@ A telemetry span of a full scenario execution globally (i.e. the exported `init/
 ```erlang
 event_name: [amoc, scenario, run, _]
 measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario => module()} %% Plus as described in `telemetry:span/3`
+metadata: #{scenario := module()} %% Plus as described in `telemetry:span/3`
 ```
 
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
 event_name: [amoc, scenario, user, _]
 measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario => module(),
-            user_id => non_neg_integer()} %% Plus as described in `telemetry:span/3`
+metadata: #{scenario := module(),
+            user_id := non_neg_integer()} %% Plus as described in `telemetry:span/3`
 ```
 
 ## Controller
@@ -22,8 +22,8 @@ metadata: #{scenario => module(),
 Indicates the number of users manually added or removed
 ```erlang
 event_name: [amoc, controller, users]
-measurements: #{count => non_neg_integer()}
-metadata: #{monotonic_time => integer(), scenario => module(), type => add | remove}
+measurements: #{count := non_neg_integer()}
+metadata: #{monotonic_time := integer(), scenario := module(), type := add | remove}
 ```
 
 ## Throttle
@@ -33,8 +33,8 @@ metadata: #{monotonic_time => integer(), scenario => module(), type => add | rem
 Raised when a throttle mechanism is initialised.
 ```erlang
 event_name: [amoc, throttle, init]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ### Rate
@@ -43,8 +43,8 @@ Raised when a throttle mechanism is initialised or its configured rate is change
 This event is raised only on the master node.
 ```erlang
 event_name: [amoc, throttle, rate]
-measurements: #{rate => non_neg_integer()}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{rate := non_neg_integer()}
+metadata: #{monotonic_time := integer(), name := atom(), msg => binary()}
 ```
 
 ### Request
@@ -52,8 +52,8 @@ metadata: #{monotonic_time => integer(), name => atom()}
 Raised when a process client requests to be allowed pass through a throttled mechanism.
 ```erlang
 event_name: [amoc, throttle, request]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ### Execute
@@ -61,8 +61,8 @@ metadata: #{monotonic_time => integer(), name => atom()}
 Raised when a process client is allowed to execute after a throttled mechanism.
 ```erlang
 event_name: [amoc, throttle, execute]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```
 
 ## Coordinator
@@ -72,6 +72,6 @@ Indicates when a coordinating event was raised, like a process being added for c
 ### Event
 ```erlang
 event_name: [amoc, coordinator, start | stop | add | reset | timeout]
-measurements: #{count => 1}
-metadata: #{monotonic_time => integer(), name => atom()}
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), name := atom()}
 ```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,12 +2,19 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
+A telemetry span of a full scenario execution globally (i.e. the exported `init/0` function):
+```erlang
+event_name: [amoc, scenario, run, _]
+measurements: #{} %% As described in `telemetry:span/3`
+metadata: #{scenario => module()} %% Plus as described in `telemetry:span/3`
+```
+
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
 event_name: [amoc, scenario, user, _]
 measurements: #{} %% As described in `telemetry:span/3`
 metadata: #{scenario => module(),
-            user_id => non_neg_integer()}
+            user_id => non_neg_integer()} %% Plus as described in `telemetry:span/3`
 ```
 
 ## Controller

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -73,5 +73,5 @@ Indicates when a coordinating event was raised, like a process being added for c
 ```erlang
 event_name: [amoc, coordinator, start | stop | add | reset | timeout]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,26 +2,32 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
-Indicates the start of a scenario after having successfully return from the `init/0` callback:
-```erlang
-event_name: [amoc, scenario, start]
-measurements: #{count := 1}
-metadata: #{monotonic_time := integer(), scenario := module()}
-```
+All telemetry spans below contain an extra key `return` in the metadata for the `stop` event with the return value of the given callback.
 
-Indicates termination of a scenario after having run the optional `terminate/` callback, and contains the return value of such:
+A telemetry span of a scenario initialisation (i.e. the exported `init/0` function):
 ```erlang
-event_name: [amoc, scenario, stop]
-measurements: #{count := 1}
-metadata: #{monotonic_time := integer(), scenario := module(), return := term()}
+event_name: [amoc, scenario, init, _]
+measurements: #{}                 %% As described in `telemetry:span/3`
+metadata: #{scenario := module()} %% Plus as described in `telemetry:span/3`
 ```
 
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
-event_name: [amoc, scenario, user, _]
-measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario := module(),
-            user_id := non_neg_integer()} %% Plus as described in `telemetry:span/3`
+event_name: [amoc, scenario, start, _]
+measurements: #{}                        %% As described in `telemetry:span/3`
+metadata: #{scenario := module(),        %% Running scenario
+            state := term(),             %% The state as returned by `init/0`
+            user_id := non_neg_integer() %% User ID assigned to the running process
+           }                             %% Plus as described in `telemetry:span/3`
+```
+
+A telemetry span of a full scenario execution for a user (i.e. the exported `terminate/1,2` function):
+```erlang
+event_name: [amoc, scenario, terminate, _]
+measurements: #{}                 %% As described in `telemetry:span/3`
+metadata: #{scenario := module(), %% Running scenario
+            state := term()       %% The state as returned by `init/0`
+           }                      %% Plus as described in `telemetry:span/3`
 ```
 
 ## Controller

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,11 +2,18 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
-A telemetry span of a full scenario execution globally (i.e. the exported `init/0` function):
+Indicates the start of a scenario after having successfully return from the `init/0` callback:
 ```erlang
-event_name: [amoc, scenario, run, _]
-measurements: #{} %% As described in `telemetry:span/3`
-metadata: #{scenario := module()} %% Plus as described in `telemetry:span/3`
+event_name: [amoc, scenario, start]
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), scenario := module()}
+```
+
+Indicates termination of a scenario after having run the optional `terminate/` callback, and contains the return value of such:
+```erlang
+event_name: [amoc, scenario, stop]
+measurements: #{count := 1}
+metadata: #{monotonic_time := integer(), scenario := module(), return := term()}
 ```
 
 A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -2,11 +2,12 @@ Amoc also exposes the following telemetry events:
 
 ## Scenario
 
-A telemetry span of a full scenario execution
+A telemetry span of a full scenario execution for a user (i.e. the exported `start/1,2` function):
 ```erlang
-event_name: [amoc, scenario, user]
-measurements: #{}
-metadata: #{}
+event_name: [amoc, scenario, user, _]
+measurements: #{} %% As described in `telemetry:span/3`
+metadata: #{scenario => module(),
+            user_id => non_neg_integer()}
 ```
 
 ## Controller

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -19,11 +19,11 @@ metadata: #{scenario => module(),
 
 ## Controller
 
-Indicates the number of users added or removed
+Indicates the number of users manually added or removed
 ```erlang
 event_name: [amoc, controller, users]
 measurements: #{count => non_neg_integer()}
-metadata: #{type => add | remove}
+metadata: #{monotonic_time => integer(), scenario => module(), type => add | remove}
 ```
 
 ## Throttle

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -31,42 +31,38 @@ metadata: #{monotonic_time => integer(), scenario => module(), type => add | rem
 ### Init
 
 Raised when a throttle mechanism is initialised.
-
 ```erlang
 event_name: [amoc, throttle, init]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Rate
 
 Raised when a throttle mechanism is initialised or its configured rate is changed.
 This event is raised only on the master node.
-
 ```erlang
 event_name: [amoc, throttle, rate]
 measurements: #{rate => non_neg_integer()}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Request
 
 Raised when a process client requests to be allowed pass through a throttled mechanism.
-
 ```erlang
 event_name: [amoc, throttle, request]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ### Execute
 
 Raised when a process client is allowed to execute after a throttled mechanism.
-
 ```erlang
 event_name: [amoc, throttle, execute]
 measurements: #{count => 1}
-metadata: #{name => atom()}
+metadata: #{monotonic_time => integer(), name => atom()}
 ```
 
 ## Coordinator

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -196,7 +196,6 @@ handle_start_scenario(Scenario, Settings, #state{status = idle} = State) ->
                                    scenario       = Scenario,
                                    scenario_state = ScenarioState,
                                    status         = running},
-            amoc_telemetry:execute([scenario, start], #{count => 1}, #{scenario => Scenario}),
             {ok, NewState};
         {error, _} = Error ->
             NewState = State#state{scenario = Scenario, status = Error},
@@ -316,9 +315,7 @@ init_scenario(Scenario, Settings) ->
 
 -spec terminate_scenario(state()) -> ok | {ok, any()} | {error, any()}.
 terminate_scenario(#state{scenario = Scenario, scenario_state = ScenarioState}) ->
-    Ret = amoc_scenario:terminate(Scenario, ScenarioState),
-    amoc_telemetry:execute([scenario, stop], #{count => 1}, #{scenario => Scenario, return => Ret}),
-    Ret.
+    amoc_scenario:terminate(Scenario, ScenarioState).
 
 -spec maybe_start_timer(timer:tref() | undefined) -> timer:tref().
 maybe_start_timer(undefined) ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -22,8 +22,6 @@
                 status = idle :: idle | running | terminating | finished |
                                  {error, any()} | disabled,
                 scenario_state :: any(), %% state returned from Scenario:init/0
-                scenario_start :: undefined | integer(),
-                scenario_ref   :: undefined | reference(),
                 create_users = [] :: [amoc_scenario:user_id()],
                 tref :: timer:tref() | undefined}).
 
@@ -192,20 +190,13 @@ handle_info(_Msg, State) ->
 -spec handle_start_scenario(module(), amoc_config:settings(), state()) ->
     {handle_call_res(), state()}.
 handle_start_scenario(Scenario, Settings, #state{status = idle} = State) ->
-    StartTime = erlang:monotonic_time(),
-    Ref = erlang:make_ref(),
     case init_scenario(Scenario, Settings) of
         {ok, ScenarioState} ->
             NewState = State#state{last_user_id   = 0,
                                    scenario       = Scenario,
                                    scenario_state = ScenarioState,
-                                   scenario_start = StartTime,
-                                   scenario_ref   = Ref,
                                    status         = running},
-            %% This simulates a span
-            telemetry:execute([amoc, scenario, run, start],
-                              #{monotonic_time => StartTime, system_time => erlang:system_time()},
-                              #{telemetry_span_context => Ref, scenario => Scenario}),
+            amoc_telemetry:execute([scenario, start], #{count => 1}, #{scenario => Scenario}),
             {ok, NewState};
         {error, _} = Error ->
             NewState = State#state{scenario = Scenario, status = Error},
@@ -323,29 +314,11 @@ init_scenario(Scenario, Settings) ->
         {error, Type, Reason} -> {error, {Type, Reason}}
     end.
 
--spec terminate_scenario(state()) ->
-    ok | {ok, any()} | {error, any()}.
-terminate_scenario(#state{scenario = Scenario,
-                          scenario_state = ScenarioState,
-                          scenario_start = StartTime,
-                          scenario_ref = Ref}) ->
-    case amoc_scenario:terminate(Scenario, ScenarioState) of
-        {error, {Class, Reason, Stacktrace}} = Ret ->
-            %% This simulates a span
-            StopTime = erlang:monotonic_time(),
-            telemetry:execute([amoc, scenario, run, exception],
-                              #{duration => StopTime - StartTime, monotonic_time => StopTime},
-                              #{telemetry_span_context => Ref, scenario => Scenario,
-                                kind => Class, reason => Reason, stacktrace => Stacktrace}),
-            Ret;
-        Ret ->
-            %% This simulates a span
-            StopTime = erlang:monotonic_time(),
-            telemetry:execute([amoc, scenario, run, stop],
-                              #{duration => StopTime - StartTime, monotonic_time => StopTime},
-                              #{telemetry_span_context => Ref, scenario => Scenario}),
-            Ret
-    end.
+-spec terminate_scenario(state()) -> ok | {ok, any()} | {error, any()}.
+terminate_scenario(#state{scenario = Scenario, scenario_state = ScenarioState}) ->
+    Ret = amoc_scenario:terminate(Scenario, ScenarioState),
+    amoc_telemetry:execute([scenario, stop], #{count => 1}, #{scenario => Scenario, return => Ret}),
+    Ret.
 
 -spec maybe_start_timer(timer:tref() | undefined) -> timer:tref().
 maybe_start_timer(undefined) ->

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -22,6 +22,8 @@
                 status = idle :: idle | running | terminating | finished |
                                  {error, any()} | disabled,
                 scenario_state :: any(), %% state returned from Scenario:init/0
+                scenario_start :: undefined | integer(),
+                scenario_ref   :: undefined | reference(),
                 create_users = [] :: [amoc_scenario:user_id()],
                 tref :: timer:tref() | undefined}).
 
@@ -192,12 +194,19 @@ handle_info(_Msg, State) ->
 -spec handle_start_scenario(module(), amoc_config:settings(), state()) ->
     {handle_call_res(), state()}.
 handle_start_scenario(Scenario, Settings, #state{status = idle} = State) ->
+    StartTime = erlang:monotonic_time(),
+    Ref = erlang:make_ref(),
     case init_scenario(Scenario, Settings) of
         {ok, ScenarioState} ->
             NewState = State#state{last_user_id   = 0,
                                    scenario       = Scenario,
                                    scenario_state = ScenarioState,
+                                   scenario_start = StartTime,
+                                   scenario_ref   = Ref,
                                    status         = running},
+            telemetry:execute([amoc, scenario, run, start],
+                              #{monotonic_time => StartTime, system_time => erlang:system_time()},
+                              #{telemetry_span_context => Ref, scenario => Scenario}),
             {ok, NewState};
         {error, _} = Error ->
             NewState = State#state{scenario = Scenario, status = Error},
@@ -207,9 +216,8 @@ handle_start_scenario(_Scenario, _Settings, #state{status = Status} = State) ->
     {{error, {invalid_status, Status}}, State}.
 
 -spec handle_stop_scenario(state()) -> {handle_call_res(), state()}.
-handle_stop_scenario(#state{scenario = Scenario, scenario_state = ScenarioState,
-                            no_of_users = 0, status = running} = State) ->
-    amoc_scenario:terminate(Scenario, ScenarioState),
+handle_stop_scenario(#state{no_of_users = 0, status = running} = State) ->
+    terminate_scenario(State),
     {ok, State#state{status = finished}};
 handle_stop_scenario(#state{status = running} = State) ->
     terminate_all_users(),
@@ -311,6 +319,28 @@ init_scenario(Scenario, Settings) ->
         {error, Type, Reason} -> {error, {Type, Reason}}
     end.
 
+-spec terminate_scenario(state()) ->
+    ok | {ok, any()} | {error, any()}.
+terminate_scenario(#state{scenario = Scenario,
+                          scenario_state = ScenarioState,
+                          scenario_start = StartTime,
+                          scenario_ref = Ref}) ->
+    case amoc_scenario:terminate(Scenario, ScenarioState) of
+        {error, {Class, Reason, Stacktrace}} = Ret ->
+            StopTime = erlang:monotonic_time(),
+            telemetry:execute([amoc, scenario, run, exception],
+                              #{duration => StopTime - StartTime, monotonic_time => StopTime},
+                              #{telemetry_span_context => Ref, scenario => Scenario,
+                                kind => Class, reason => Reason, stacktrace => Stacktrace}),
+            Ret;
+        Ret ->
+            StopTime = erlang:monotonic_time(),
+            telemetry:execute([amoc, scenario, run, stop],
+                              #{duration => StopTime - StartTime, monotonic_time => StopTime},
+                              #{telemetry_span_context => Ref, scenario => Scenario}),
+            Ret
+    end.
+
 -spec maybe_start_timer(timer:tref() | undefined) -> timer:tref().
 maybe_start_timer(undefined) ->
     {ok, TRef} = timer:send_interval(interarrival(), start_user),
@@ -347,9 +377,8 @@ terminate_all_users({Objects, Continuation}) ->
 terminate_all_users('$end_of_table') -> ok.
 
 -spec dec_no_of_users(state()) -> state().
-dec_no_of_users(#state{scenario = Scenario, scenario_state = ScenarioState,
-                       no_of_users = 1, status = terminating} = State) ->
-    amoc_scenario:terminate(Scenario, ScenarioState),
+dec_no_of_users(#state{no_of_users = 1, status = terminating} = State) ->
+    terminate_scenario(State),
     State#state{no_of_users = 0, status = finished};
 dec_no_of_users(#state{no_of_users = N} = State) ->
     State#state{no_of_users = N - 1}.

--- a/src/amoc_coordinator/amoc_coordinator.erl
+++ b/src/amoc_coordinator/amoc_coordinator.erl
@@ -74,7 +74,8 @@ start(Name, CoordinationPlan, Timeout) when ?IS_TIMEOUT(Timeout) ->
     Plan = normalize_coordination_plan(CoordinationPlan),
     case gen_event:start({local, Name}) of
         {ok, _} ->
-            telemetry:execute([amoc, coordinator, start], #{count => 1}, #{name => Name}),
+            telemetry:execute([amoc, coordinator, start], #{count => 1},
+                              #{monotonic_time => erlang:monotonic_time(), name => Name}),
             %% according to gen_event documentation:
             %%
             %%    When the event is received, the event manager calls
@@ -99,7 +100,8 @@ start(Name, CoordinationPlan, Timeout) when ?IS_TIMEOUT(Timeout) ->
 -spec stop(name()) -> ok.
 stop(Name) ->
     gen_event:stop(Name),
-    telemetry:execute([amoc, coordinator, stop], #{count => 1}, #{name => Name}).
+    telemetry:execute([amoc, coordinator, stop], #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
 
 %% @see add/3
 -spec add(name(), any()) -> ok.
@@ -163,8 +165,8 @@ handle_event(Event, {timeout, Name, Pid}) ->
                          reset_coordinator -> reset;
                          coordinator_timeout -> timeout
                      end,
-    telemetry:execute([amoc, coordinator, TelemetryEvent],
-                       #{count => 1}, #{name => Name}),
+    telemetry:execute([amoc, coordinator, TelemetryEvent], #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}),
     erlang:send(Pid, Event),
     {ok, {timeout, Name, Pid}};
 handle_event(Event, {worker, WorkerPid}) ->

--- a/src/amoc_telemetry.erl
+++ b/src/amoc_telemetry.erl
@@ -1,0 +1,15 @@
+%% @private
+%% @copyright 2023 Erlang Solutions Ltd.
+-module(amoc_telemetry).
+
+-export([execute/3]).
+
+-spec execute(EventName, Measurements, Metadata) -> ok when
+      EventName :: telemetry:event_name(),
+      Measurements :: telemetry:event_measurements(),
+      Metadata :: telemetry:event_metadata().
+execute(Name, Measurements, Metadata) ->
+    TimeStamp = erlang:monotonic_time(),
+    NameWithAmocPrefix = [amoc | Name],
+    MetadataWithTS = Metadata#{monotonic_time => TimeStamp},
+    telemetry:execute(NameWithAmocPrefix, Measurements, MetadataWithTS).

--- a/src/amoc_throttle/amoc_throttle_controller.erl
+++ b/src/amoc_throttle/amoc_throttle_controller.erl
@@ -204,7 +204,14 @@ maybe_raise_event(Name, Event) ->
     end.
 
 raise_event(Name, Event) when Event =:= request; Event =:= execute; Event =:= init ->
-    telemetry:execute([amoc, throttle, Event], #{count => 1}, #{name => Name}).
+    telemetry:execute([amoc, throttle, Event],
+                      #{count => 1},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
+
+report_rate(Name, RatePerMinute) ->
+    telemetry:execute([amoc, throttle, rate],
+                      #{rate => RatePerMinute},
+                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
 
 -spec change_rate_and_stop_plan(name(), state()) -> state().
 change_rate_and_stop_plan(Name, State) ->
@@ -329,6 +336,3 @@ run_cmd(Pid, pause) ->
     amoc_throttle_process:pause(Pid);
 run_cmd(Pid, resume) ->
     amoc_throttle_process:resume(Pid).
-
-report_rate(Name, RatePerMinute) ->
-    telemetry:execute([amoc, throttle, rate], #{rate => RatePerMinute}, #{name => Name}).

--- a/src/amoc_throttle/amoc_throttle_controller.erl
+++ b/src/amoc_throttle/amoc_throttle_controller.erl
@@ -204,14 +204,10 @@ maybe_raise_event(Name, Event) ->
     end.
 
 raise_event(Name, Event) when Event =:= request; Event =:= execute; Event =:= init ->
-    telemetry:execute([amoc, throttle, Event],
-                      #{count => 1},
-                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
+    amoc_telemetry:execute([throttle, Event], #{count => 1}, #{name => Name}).
 
 report_rate(Name, RatePerMinute) ->
-    telemetry:execute([amoc, throttle, rate],
-                      #{rate => RatePerMinute},
-                      #{monotonic_time => erlang:monotonic_time(), name => Name}).
+    amoc_telemetry:execute([throttle, rate], #{rate => RatePerMinute}, #{name => Name}).
 
 -spec change_rate_and_stop_plan(name(), state()) -> state().
 change_rate_and_stop_plan(Name, State) ->

--- a/src/amoc_user.erl
+++ b/src/amoc_user.erl
@@ -27,5 +27,6 @@ stop(Pid, Force) when is_pid(Pid) ->
 init(Parent, Scenario, Id, State) ->
     proc_lib:init_ack(Parent, {ok, self()}),
     process_flag(trap_exit, true),
-    ScenarioFun = fun() -> {amoc_scenario:start(Scenario, Id, State), #{}} end,
-    telemetry:span([amoc, scenario, user], #{}, ScenarioFun).
+    Metadata = #{scenario => Scenario, user_id => Id},
+    ScenarioFun = fun() -> {amoc_scenario:start(Scenario, Id, State), Metadata} end,
+    telemetry:span([amoc, scenario, user], Metadata, ScenarioFun).

--- a/src/amoc_user.erl
+++ b/src/amoc_user.erl
@@ -27,6 +27,4 @@ stop(Pid, Force) when is_pid(Pid) ->
 init(Parent, Scenario, Id, State) ->
     proc_lib:init_ack(Parent, {ok, self()}),
     process_flag(trap_exit, true),
-    Metadata = #{scenario => Scenario, user_id => Id},
-    ScenarioFun = fun() -> {amoc_scenario:start(Scenario, Id, State), Metadata} end,
-    telemetry:span([amoc, scenario, user], Metadata, ScenarioFun).
+    amoc_scenario:start(Scenario, Id, State).

--- a/test/amoc_coordinator_SUITE.erl
+++ b/test/amoc_coordinator_SUITE.erl
@@ -327,9 +327,8 @@ assert_telemetry_events(Name, [{_Pid, Call, _Ret} | History], [Event | EventList
 assert_telemetry_handler_call(Name, Call, Event) ->
     EventName = [amoc, coordinator, Event],
     Measurements = #{count => 1},
-    EventMetadata = #{name => Name},
     HandlerConfig = ?TELEMETRY_HANDLER_CONFIG,
-    ExpectedHandlerCall = {?TELEMETRY_HANDLER, handler,
-                           [EventName, Measurements,
-                            EventMetadata, HandlerConfig]},
-    ?assertEqual(ExpectedHandlerCall, Call).
+    ?assertMatch(
+       {?TELEMETRY_HANDLER, handler,
+        [EventName, Measurements,
+         #{name := Name, monotonic_time := _}, HandlerConfig]}, Call).


### PR DESCRIPTION
I'm going to want timestamps for all these telemetry events, so that metrics collectors can aggregate and draw plots based on time.

I also want an event for scenario start and stop which will mimic telemetry's span mechanism, but which here it is done in this way because the controller separately calls the beginning and the end of the scenario and span wouldn't fit into this mechanism.

Split from #155 