### PR TITLE
Controller/Return a more explicit running status from

### DIFF
--- a/integration_test/extra_code_paths/path1/dummy_helper.erl
+++ b/integration_test/extra_code_paths/path1/dummy_helper.erl
@@ -12,7 +12,7 @@ test_amoc_dist() ->
         Slaves = amoc_cluster:slave_nodes(),
         %% check the status of the nodes
         disabled = rpc:call(Master, amoc_controller, get_status, []),
-        [{running, dummy_scenario, _, _} = rpc:call(Node, amoc_controller, get_status, [])
+        [{running, #{scenario := dummy_scenario}} = rpc:call(Node, amoc_controller, get_status, [])
          || Node <- Slaves],
         %% check user ids
         {N1, Nodes1, Ids1, Max1} = get_users_info(Slaves),

--- a/src/amoc.erl
+++ b/src/amoc.erl
@@ -35,7 +35,7 @@ do(Scenario, Count, Settings) ->
 add(Count) when is_integer(Count), Count > 0 ->
     case is_running_locally() of
         ok ->
-            {running, _, _, LastUserId} = amoc_controller:get_status(),
+            {running, #{highest_user_id := LastUserId}} = amoc_controller:get_status(),
             amoc_controller:add_users(LastUserId + 1, LastUserId + Count);
         Error -> Error
     end.

--- a/src/amoc_controller.erl
+++ b/src/amoc_controller.erl
@@ -28,8 +28,12 @@
 -type state() :: #state{}.
 %% Internal state of the node's controller
 -type handle_call_res() :: ok | {ok, term()} | {error, term()}.
+-type running_status() :: #{scenario := amoc:scenario(),
+                            currently_running_users := user_count(),
+                            highest_user_id := last_user_id()}.
+%% Details about the scenario currently running
 -type amoc_status() :: idle |
-                       {running, amoc:scenario(), user_count(), last_user_id()} |
+                       {running, running_status()} |
                        {terminating, amoc:scenario()} |
                        {finished, amoc:scenario()} |
                        {error, any()} |
@@ -259,7 +263,7 @@ handle_remove(_Count, _ForceRemove, #state{status = Status}) ->
 -spec handle_status(state()) -> amoc_status().
 handle_status(#state{status = running, scenario = Scenario,
                      no_of_users = N, last_user_id = LastId}) ->
-    {running, Scenario, N, LastId};
+    {running, #{scenario => Scenario, currently_running_users => N, highest_user_id => LastId}};
 handle_status(#state{status = terminating, scenario = Scenario}) ->
     {terminating, Scenario};
 handle_status(#state{status = finished, scenario = Scenario}) ->

--- a/test/controller_SUITE.erl
+++ b/test/controller_SUITE.erl
@@ -82,7 +82,11 @@ start_scenario_runs_fine(_) ->
 start_scenario_check_status(_) ->
     do_start_scenario(testing_scenario, regular_vars()),
     Status = amoc_controller:get_status(),
-    ?assertMatch({running, testing_scenario, 0, 0}, Status).
+    ?assertMatch(
+       {running, #{scenario := testing_scenario,
+                   currently_running_users := 0,
+                   highest_user_id := 0}},
+       Status).
 
 add_users_to_started_scenario(_) ->
     do_start_scenario(testing_scenario, regular_vars()),
@@ -178,5 +182,7 @@ other_vars_to_keep_quiet() ->
 
 wait_until_scenario_has_users(Scenario, Current, HighestId) ->
     WaitUntilFun = fun amoc_controller:get_status/0,
-    WaitUntilValue = {running, Scenario, Current, HighestId},
+    WaitUntilValue = {running, #{scenario => Scenario,
+                                 currently_running_users => Current,
+                                 highest_user_id => HighestId}},
     async_helper:wait_until(WaitUntilFun, WaitUntilValue).


### PR DESCRIPTION
This way the map has keys with proper names for the fields we're looking at.