### PR TITLE
Controller/Deduplicate user supervision

### DIFF
--- a/integration_test/extra_code_paths/path1/dummy_helper.erl
+++ b/integration_test/extra_code_paths/path1/dummy_helper.erl
@@ -66,7 +66,7 @@ test_amoc_dist() ->
 get_users_info(SlaveNodes) ->
     Users = [{Node, Id} ||
         Node <- SlaveNodes,
-        {Id, _Pid} <- rpc:call(Node, ets, tab2list, [amoc_users])],
+        {_Pid, Id} <- rpc:call(Node, ets, tab2list, [amoc_users])],
     Ids = lists:usort([Id || {_, Id} <- Users]),
     Nodes = lists:usort([Node || {Node, _} <- Users]),
     N = length(Ids),

--- a/src/amoc_sup.erl
+++ b/src/amoc_sup.erl
@@ -31,9 +31,9 @@ start_link() ->
           [ChildSpec :: supervisor:child_spec()]
     }}.
 init([]) ->
-    {ok, {{one_for_one, 5, 10},
+    {ok, {{rest_for_one, 5, 10},
           [
-              ?SUP(amoc_users_sup, supervisor),
+              ?WORKER(amoc_users_sup, worker),
               ?SUP(amoc_throttle_sup, supervisor),
               ?SUP(amoc_coordinator_sup, supervisor),
               ?WORKER(amoc_controller, worker),

--- a/src/users/amoc_user.erl
+++ b/src/users/amoc_user.erl
@@ -10,7 +10,7 @@
 -type state() :: term().
 
 -spec start_link(amoc:scenario(), amoc_scenario:user_id(), state()) ->
-    {ok, pid()}.
+    {ok, pid()} | {error, term()}.
 start_link(Scenario, Id, State) ->
     proc_lib:start_link(?MODULE, init, [self(), Scenario, Id, State]).
 

--- a/src/users/amoc_users_sup.erl
+++ b/src/users/amoc_users_sup.erl
@@ -1,25 +1,127 @@
 %% @private
 %% @copyright 2023 Erlang Solutions Ltd.
+%% @doc Supervisor-like gen_server with some tracking responsibilities over the users
+%%
+%% We want to keep consistent track of all users running globally by running special code upon a
+%% children's death. Standard solutions don't cut it because:
+%%  - A supervisor doesn't expose callbacks on user termination
+%%  - Implementing code on the user process before it dies risks inconsistencies if it is killed
+%%  More improvements that could be made would be to distribute the supervision tree like ranch did,
+%%  see https://stressgrid.com/blog/100k_cps_with_elixir/
+%% @end
 -module(amoc_users_sup).
--behaviour(supervisor).
 
--export([start_link/0, stop_child/2, stop_children/2]).
--export([init/1]).
+-behaviour(gen_server).
+-define(USERS_TABLE, amoc_users).
 
--define(SERVER, ?MODULE).
+%% gen_server callbacks
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+%% API for amoc_controller, always async to not block the controller
+-export([start_child/3, stop_child/2,
+         count_children/0, stop_children/2,
+         terminate_all_children/0]).
+
+-record(state, {
+          no_of_users = 0 :: non_neg_integer()
+         }).
+-type state() :: #state{}.
+
 -define(SHUTDOWN_TIMEOUT, 2000). %% 2 seconds
 
--spec start_link() -> {ok, Pid :: pid()}.
+%% @private
+-spec start_link() -> {ok, pid()}.
 start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% ------------------------------------------------------------------
+%% API
+%% ------------------------------------------------------------------
+
+-spec count_children() -> non_neg_integer().
+count_children() ->
+    ets:info(?USERS_TABLE, size).
+
+-spec terminate_all_children() -> any().
+terminate_all_children() ->
+    gen_server:cast(?MODULE, terminate_all_children).
+
+-spec start_child(amoc:scenario(), amoc_scenario:user_id(), any()) -> ok.
+start_child(Scenario, Id, ScenarioState) ->
+    gen_server:cast(?MODULE, {start_child, Scenario, Id, ScenarioState}).
+
+-spec stop_children(non_neg_integer(), boolean()) -> non_neg_integer().
+stop_children(Count, ForceRemove) ->
+    Size = ets:info(?USERS_TABLE, size),
+    CountRemove = min(Count, Size),
+    gen_server:cast(?MODULE, {stop_children, CountRemove, ForceRemove}),
+    CountRemove.
 
 -spec stop_child(pid(), boolean()) -> ok | {error, any()}.
 stop_child(Pid, true) ->
     Node = node(Pid),
-    supervisor:terminate_child({amoc_users_sup, Node}, Pid);
+    gen_server:call({?MODULE, Node}, {stop_child, Pid});
 stop_child(Pid, false) when is_pid(Pid) ->
-    exit(Pid, shutdown), %% do it in the same way as supervisor!!!
+    exit(Pid, shutdown), %% do it in the same way as the supervisor
     ok.
+
+%% ------------------------------------------------------------------
+%% gen_server code
+%% ------------------------------------------------------------------
+
+%% @private
+-spec init(term()) -> {ok, term()}.
+init([]) ->
+    Opts = [named_table, ordered_set, protected, {read_concurrency, true}],
+    ?USERS_TABLE = ets:new(?USERS_TABLE, Opts),
+    process_flag(trap_exit, true),
+    process_flag(priority, high),
+    {ok, #state{no_of_users = 0}}.
+
+%% @private
+-spec handle_call(any(), any(), state()) -> {reply, term(), state()}.
+handle_call({stop_child, Pid}, _From, State) ->
+    {Return, NewState} = handle_stop_user(Pid, State),
+    {reply, Return, NewState};
+handle_call(_Request, _From, State) ->
+    {reply, {error, not_implemented}, State}.
+
+%% @private
+-spec handle_cast(any(), state()) -> {noreply, state()}.
+handle_cast({start_child, Scenario, Id, ScenarioState}, #state{no_of_users = N} = State) ->
+    case amoc_user:start_link(Scenario, Id, ScenarioState) of
+        {ok, Pid} ->
+            ets:insert(?USERS_TABLE, {Pid, Id}),
+            {noreply, State#state{no_of_users = N + 1}};
+        _ ->
+            {noreply, State}
+    end;
+handle_cast({stop_children, CountRemove, ForceRemove}, State) ->
+    Pids = case ets:match_object(?USERS_TABLE, '$1', CountRemove) of
+               {Objects, _} -> [Pid || {Pid, _Id} <- Objects];
+               '$end_of_table' -> []
+           end,
+    do_stop_children(Pids, ForceRemove),
+    {noreply, State};
+handle_cast(terminate_all_children, State) ->
+    do_terminate_all_children(),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({'EXIT', Pid, _Reason}, State) ->
+    {_, NewState} = handle_stop_user(Pid, State),
+    {noreply, NewState};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    do_terminate_all_children().
 
 %% @doc Stop users, possibly in parallel
 %%
@@ -31,11 +133,11 @@ stop_child(Pid, false) when is_pid(Pid) ->
 %% users may take take `N * ?SHUTDOWN_TIMEOUT' milliseconds, which is
 %% not acceptable. So let's do the same thing as the supervisor but in
 %% parallel, so it won't result in a huge delay.
--spec stop_children([pid()], boolean()) -> ok.
-stop_children(Pids, false) ->
+-spec do_stop_children([pid()], boolean()) -> ok.
+do_stop_children(Pids, false) ->
     [stop_child(Pid, false) || Pid <- Pids],
     ok;
-stop_children(Pids, true) ->
+do_stop_children(Pids, true) ->
     spawn(
         fun() ->
             [exit(Pid, shutdown) || Pid <- Pids],
@@ -44,17 +146,31 @@ stop_children(Pids, true) ->
         end),
     ok.
 
--spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
-init([]) ->
-    process_flag(priority, high),
-    SupFlags = #{strategy => simple_one_for_one},
-    AChild = #{id => amoc_user,
-               start => {amoc_user, start_link, []},
-               %% A temporary child process is never restarted
-               restart => temporary,
-               %% sending exit(Child,shutdown) first. If a process doesn't stop within
-               %% the shutdown timeout, than killing it brutally with exit(Child,kill).
-               shutdown => ?SHUTDOWN_TIMEOUT,
-               type => worker,
-               modules => [amoc_user]},
-    {ok, {SupFlags, [AChild]}}.
+handle_stop_user(Pid, State) ->
+    case ets:member(?USERS_TABLE, Pid) of
+        true ->
+            ets:delete(?USERS_TABLE, Pid),
+            {ok, dec_no_of_users(State)};
+        false ->
+            {{error, not_found}, State}
+    end.
+
+dec_no_of_users(#state{no_of_users = 1} = State) ->
+    amoc_controller:zero_users_running(),
+    State#state{no_of_users = 0};
+dec_no_of_users(#state{no_of_users = N} = State) ->
+    State#state{no_of_users = N - 1}.
+
+-spec do_terminate_all_children() -> any().
+do_terminate_all_children() ->
+    Match = ets:match_object(?USERS_TABLE, '$1', 200),
+    do_terminate_all_children(Match).
+
+%% ets:continuation/0 type is unfortunately not exported from the ets module.
+-spec do_terminate_all_children({tuple(), term()} | '$end_of_table') -> ok.
+do_terminate_all_children({Objects, Continuation}) ->
+    Pids = [Pid || {Pid, _Id} <- Objects],
+    do_stop_children(Pids, true),
+    Match = ets:match_object(Continuation),
+    do_terminate_all_children(Match);
+do_terminate_all_children('$end_of_table') -> ok.


### PR DESCRIPTION
In the original implementation, the process is monitored by two supervisors, the original amoc_users_sup, and the amoc_controller one. But this means that bursts of ups and downs overflow the mailbox of _two_ processes, one of them being actually the very critical controller.

With this reimplementation, only the amoc_users_sup tracks the processes, and all requests from the controller are asynchronous. This ensures the controller does not get blocked and can remain responsive to control requests.