### PR TITLE
Controller/Support interarrival of zero

### DIFF
--- a/test/controller_SUITE.erl
+++ b/test/controller_SUITE.erl
@@ -32,6 +32,7 @@ all_tests() ->
      stop_running_scenario_with_no_users_immediately_terminates,
      stop_running_scenario_with_users_stays_in_finished,
      stop_running_scenario_with_users_eventually_terminates,
+     interarrival_equal_zero_starts_all_users_at_once,
      scenario_with_state_and_crashing_in_terminate_run_fine,
      scenario_missing_start_callback_fails,
      scenario_with_failing_init_fails
@@ -154,6 +155,14 @@ stop_running_scenario_with_users_eventually_terminates(_) ->
     WaitUntilFun = fun amoc_controller:get_status/0,
     WaitUntilValue = {finished, testing_scenario},
     wait_helper:wait_until(WaitUntilFun, WaitUntilValue).
+
+interarrival_equal_zero_starts_all_users_at_once(_) ->
+    Vars = [{interarrival, 0}, {testing_var1, def1} | test_helpers:other_vars_to_keep_quiet()],
+    do_start_scenario(testing_scenario, Vars),
+    NumOfUsers = 1000,
+    amoc_controller:add_users(1, NumOfUsers),
+    Extra = #{time_left => 25, sleep_time => 5},
+    test_helpers:wait_until_scenario_has_users(testing_scenario, NumOfUsers, NumOfUsers, Extra).
 
 scenario_with_state_and_crashing_in_terminate_run_fine(_) ->
     do_start_scenario(testing_scenario_with_state, test_helpers:regular_vars_with_state()),


### PR DESCRIPTION
Useful if for example we want to spawn a big pool of users all at once. Optimised by not setting any timers, but simply looping new user requests.