### PR TITLE
Add telemetry event for a coordinator trigger

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -96,13 +96,22 @@ metadata: #{monotonic_time := integer(),
 
 ## Coordinator
 
+### Event
 Indicates when a coordinating event was raised, like a process being added for coordination or a timeout being triggered
 
-### Event
 ```erlang
 event_name: [amoc, coordinator, start | stop | add | reset | timeout]
 measurements: #{count := 1}
 metadata: #{monotonic_time := integer(), name := atom()}
+```
+
+### Action triggered
+Indicates an action is about to be triggered, either by enough users in the group or by timeout
+
+```erlang
+event_name: [amoc, coordinator, execute]
+measurements: #{count := num_of_users()}
+metadata: #{monotonic_time := integer(), event := coordinate | reset | timeout | stop}
 ```
 
 ## Config

--- a/src/amoc_coordinator/amoc_coordinator_worker.erl
+++ b/src/amoc_coordinator/amoc_coordinator_worker.erl
@@ -99,7 +99,11 @@ maybe_reset_state(State) ->
     State.
 
 -spec reset_state(event_type(), state()) -> state().
-reset_state(Event, #state{actions = Actions, accumulator = Acc, n = N} = State) ->
+reset_state(Event, #state{actions = Actions,
+                          accumulator = Acc,
+                          n = N, required_n = ReqN} = State) ->
+    amoc_telemetry:execute([coordinator, execute], #{count => N},
+                           #{event => Event, configured => ReqN}),
     [execute_action(Action, {Event, N}, Acc) || Action <- Actions],
     State#state{accumulator = [], n = 0}.
 


### PR DESCRIPTION
Indicates an action is about to be triggered, either by enough users in the group or by timeout.