### PR TITLE
Allow any term to be a coordinator name

### DIFF
--- a/src/coordinator/amoc_coordinator.erl
+++ b/src/coordinator/amoc_coordinator.erl
@@ -19,7 +19,7 @@
 -define(IS_N_OF_USERS(N), (?IS_POS_INT(N) orelse N =:= all)).
 -define(IS_TIMEOUT(Timeout), (?IS_POS_INT(Timeout) orelse Timeout =:= infinity)).
 
--type name() :: atom().
+-type name() :: term().
 
 -type data() :: {pid(), Data :: any()}.
 
@@ -102,11 +102,11 @@ reset(Name) ->
     notify(Name, reset_coordinator).
 
 -spec notify(name(), coordinator_timeout | reset_coordinator | {coordinate, {pid(), term()}}) -> ok.
-notify(Name, coordinator_timeout) when is_atom(Name) ->
+notify(Name, coordinator_timeout) ->
     do_notify(Name, coordinator_timeout);
-notify(Name, reset_coordinator) when is_atom(Name) ->
+notify(Name, reset_coordinator) ->
     do_notify(Name, reset_coordinator);
-notify(Name, {coordinate, _} = Event) when is_atom(Name) ->
+notify(Name, {coordinate, _} = Event) ->
     do_notify(Name, Event).
 
 do_notify(Name, Event) ->

--- a/src/coordinator/amoc_coordinator_sup.erl
+++ b/src/coordinator/amoc_coordinator_sup.erl
@@ -68,7 +68,6 @@ start_link() ->
 
 -spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
-    ets:new(?MODULE,  [named_table, ordered_set, public, {read_concurrency, true}]),
     AChild = #{id => amoc_coordinator_worker_sup,
                start => {amoc_coordinator_worker_sup, start_link, []},
                restart => transient,


### PR DESCRIPTION
This comes from when the name was the name of a registered process, and
hence the Erlang registry required it be an atom, but now it is an
opaque term stored in a persistent term, hence allowing the flexibility
for it to be any term allows us to create coordinators dynamically.

One example of when this might be desired is when coordinating members
of a groupchat: when the groupchat is created, a coordinator is created
with the name of the groupchat, and the members will add themselves to
this coordinator. This way, they can coordinate setting presences and
messages within the namespace of that room alone.