### PR TITLE
Upgrade dependencies and runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     name: ${{ matrix.test-type }} test on OTP ${{matrix.otp_vsn}}
     strategy:
       matrix:
-        otp_vsn: ['27', '26', '25']
-        rebar_vsn: ['3.24']
+        otp_vsn: ['28', '27', '26']
+        rebar_vsn: ['3.25']
         test-type: ['regular', 'integration']
     runs-on: 'ubuntu-24.04'
     steps:

--- a/rebar.config
+++ b/rebar.config
@@ -4,14 +4,14 @@
 ]}.
 
 {deps, [
-    {telemetry, "1.3.0"}
+    {telemetry, "~> 1.3"}
 ]}.
 
 {profiles, [
     {test, [
         {deps, [
             {meck, "1.0.0"},
-            {proper, "1.4.0"},
+            {proper, "1.5.0"},
             {bbmustache, "1.12.2"},
             {wait_helper, "0.2.1"}
         ]}

--- a/test/amoc_config_scenario_SUITE.erl
+++ b/test/amoc_config_scenario_SUITE.erl
@@ -207,10 +207,9 @@ update_settings_readonly(_) ->
                         {config_scenario_var1, val1}, %% the same value as set initially
                         {config_scenario_var3, val3}],
     ReadOnlyRet = amoc_config_scenario:update_settings(ScenarioSettings),
-    ?assertEqual({error, readonly_parameters,
-                  [{config_scenario_var0, ?MODULE},
-                   {config_scenario_var1, ?MODULE}]},
-                 ReadOnlyRet),
+    ?assertMatch({error, readonly_parameters, _Vars}, ReadOnlyRet),
+    {error, readonly_parameters, Vars} = ReadOnlyRet,
+    is_equal_list([{config_scenario_var0, ?MODULE}, {config_scenario_var1, ?MODULE}], Vars),
     is_equal_list(Table, ets:tab2list(amoc_config)),
     assert_no_update_calls(),
     assert_no_verify_calls().


### PR DESCRIPTION
Support for OTP28.

Also, a test became flaky after the fact that `ets:tab2list/1` might return values in a different order in different versions of OTP, so we here just want to capture the value and compare after sorting.