### PR TITLE
Fix Elvis

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -1,0 +1,22 @@
+[{elvis, [
+    {config, [
+        #{
+            dirs => ["src/**"],
+            filter => "*.erl",
+            ruleset => erl_files,
+            rules => [
+                {elvis_text_style, line_length, #{skip_comments => whole_line}},
+                {elvis_style, export_used_types, disable},
+                {elvis_style, private_data_types, disable},
+                {elvis_style, no_invalid_dynamic_calls, #{ignore => [{amoc_code_server, get_md5}]}},
+                {elvis_style, no_block_expressions, #{ignore => [amoc_cluster]}},
+                {elvis_style, no_throw, #{ignore => [amoc_config]}}
+            ]
+        },
+        #{
+            dirs => ["."],
+            filter => "rebar.config",
+            ruleset => rebar_config
+        }
+    ]}
+]}].

--- a/rebar.config
+++ b/rebar.config
@@ -67,24 +67,3 @@
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.
-
-{elvis, [
-    #{
-        dirs => ["src/**"],
-        filter => "*.erl",
-        ruleset => erl_files,
-        rules => [
-            {elvis_text_style, line_length, #{skip_comments => whole_line}},
-            {elvis_style, export_used_types, disable},
-            {elvis_style, private_data_types, disable},
-            {elvis_style, no_invalid_dynamic_calls, #{ignore => [{amoc_code_server, get_md5}]}},
-            {elvis_style, no_block_expressions, #{ignore => [amoc_cluster]}},
-            {elvis_style, no_throw, #{ignore => [amoc_config]}}
-        ]
-    },
-    #{
-        dirs => ["."],
-        filter => "rebar.config",
-        ruleset => rebar_config
-    }
-]}.


### PR DESCRIPTION
`rebar3_lint` (which uses elvis) started failing after the [last release](https://github.com/project-fifo/rebar3_lint/releases/tag/4.2.3). See #194 for an example. For some reason, it stopped accepting configuration in `rebar.config` and now requires a separate `elvis.config`.